### PR TITLE
Fix: Update GitHub Actions matrix strategy for OS selection

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ${{ github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main' && fromJson('["ubuntu-latest", "windows-latest", "macos-latest"]') || fromJson('["ubuntu-latest"]') }}
+        os: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main')) && fromJson('["ubuntu-latest", "windows-latest", "macos-latest"]') || fromJson('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
The merge commit into main did not run any tests as it evaluated to "True". This should fix it. 
