### PR TITLE
FIX & Enhance: All-in-one Installation, and tqdm progress bars

### DIFF
--- a/packages/pixel-patrol-base/pyproject.toml
+++ b/packages/pixel-patrol-base/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "tensorboard>=2.18.0", # TODO: Are we sure we want it in base?
     "tensorboardx>=2.6.4", # TODO: Are we sure we want it in base?
     "dask>=2025.5.1",
+    "tqdm>=4.67.1",
 ]
 
 [tool.uv]

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/api.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/api.py
@@ -39,10 +39,18 @@ def process_files(project: Project) -> Project:
     logger.info(f"API Call: Processing files and building DataFrame for project '{project.name}'.")
     return project.process_records()
 
-def show_report(project: Project, host: str = "127.0.0.1", port: int = None) -> None:
+def show_report(project: Project, host: str = "127.0.0.1", port: int = None, debug: bool = False) -> None:
+    """
+    Run without the Flask debug reloader by default. The debug reloader
+    spawns a second process and will re-import/run the script, which causes
+    the example to execute twice (scan/process files two times). When a
+    developer needs the interactive debugger they can pass `debug=True`,
+    but should also set `use_reloader=False` if they do not want the script
+    re-executed.
+    """
     logger.info(f"API Call: Showing report for project '{project.name}'.")
     app = create_app(project)
-    app.run(debug=True, host=host, port=port)
+    app.run(debug=debug, host=host, port=port, use_reloader=False)
 
 def export_project(project: Project, dest: Path) -> None: # TODO: think about when project can be saved
     logger.info(f"API Call: Exporting project '{project.name}' to '{dest}'.")

--- a/packages/pixel-patrol/pyproject.toml
+++ b/packages/pixel-patrol/pyproject.toml
@@ -23,4 +23,4 @@ dev = [
 pixel-patrol-base = { path = "../pixel-patrol-base" }
 pixel-patrol-image = { path = "../pixel-patrol-image" }
 pixel-patrol-loader-zarr = { path = "../pixel-patrol-loader-zarr" }
-pixel-patrol-loader-bioio = { path = "../pixel-patrol-loader-bioio" }
+pixel-patrol-loader-bio = { path = "../pixel-patrol-loader-bio" }


### PR DESCRIPTION
FIX: All-in-one Installation for local UV installation adjusted to use the new `pixel-patrol-loader-bio`.
FIX: Run file processing just once. 
ENHANCE: tqdm progress bars for files and processes. Hence, manual timing of file laoding got removed.
Closes #24 

