### PR TITLE
BUILD(deps): version bumps 

### DIFF
--- a/packages/pixel-patrol-base/pyproject.toml
+++ b/packages/pixel-patrol-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixel-patrol-base"
-version = "0.1.2"
+version = "0.1.3"
 description = "Image prevalidation tool"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/pixel-patrol-image/pyproject.toml
+++ b/packages/pixel-patrol-image/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "pixel-patrol-image"
-version = "0.1.2"
+version = "0.1.3"
 description = "Image prevalidation tool"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = [
-    "pixel-patrol-base==0.1.2",
+    "pixel-patrol-base>=0.1.2",
     "opencv-python-headless>=4.8",
 ]
 

--- a/packages/pixel-patrol-loader-bio/pyproject.toml
+++ b/packages/pixel-patrol-loader-bio/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixel-patrol-loader-bio"
-version = "0.1.2"
+version = "0.1.3"
 description = "PixelPatrol add-on package for loading images with bioio and zarr"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -11,7 +11,7 @@ dependencies = [
     "bioio-ome-tiff==1.4.0",
     "bioio-ome-zarr==2.3.0",
     "bioio-imageio==1.3.0",
-    "pixel-patrol-base==0.1.2",
+    "pixel-patrol-base>=0.1.2",
     "zarr==3.1.1",
     "tifffile==2025.9.9",
 ]

--- a/packages/pixel-patrol/pyproject.toml
+++ b/packages/pixel-patrol/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "pixel-patrol"
-version = "0.3.2"
+version = "0.3.3"
 description = "Image prevalidation tool - PixelPatrol and its add-ons packages"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = [
-    "pixel-patrol-base==0.1.2",
-    "pixel-patrol-image==0.1.2",
-    "pixel-patrol-loader-bio==0.1.2",
+    "pixel-patrol-base==0.1.3",
+    "pixel-patrol-image>=0.1.2",
+    "pixel-patrol-loader-bio>=0.1.2",
 ]
 
 [tool.uv]


### PR DESCRIPTION
Version bumps to ensure compatibility across plugins and versions when updating just one

Requires releasing all 4 packages on PyPi again, to make the hot-fix for histograms (introduced in #73 ) available via `pip install` .