### PR TITLE
fix multiple processors handling of NaN-containing images

### DIFF
--- a/packages/pixel-patrol-base/src/pixel_patrol_base/config.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/config.py
@@ -12,3 +12,5 @@ DEFAULT_RECORDS_FLUSH_EVERY_N: int = 10000
 COMBINE_HEADROOM_RATIO = 1.5
 # Maximum number of intermediate flushes allowed to avoid overwhelming the system with too many tasks.
 MAX_INTERMEDIATE_FLUSHES = 1000
+
+HISTOGRAM_BINS = 256

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/basic_stats_processor.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/basic_stats_processor.py
@@ -11,10 +11,10 @@ logger = logging.getLogger(__name__)
 
 def _column_fn_registry() -> Dict[str, Dict[str, Callable]]:
     return {
-        'mean_intensity': {'fn': lambda a: np.float32(np.mean(a)) if a.size else np.float32(np.nan), 'agg': np.mean},
-        'std_intensity': {'fn': lambda a: np.float32(np.std(a)) if a.size else np.float32(np.nan), 'agg': np.mean},
-        'min_intensity': {'fn': lambda a: np.float32(np.min(a)) if a.size else np.float32(np.nan), 'agg': np.min},
-        'max_intensity': {'fn': lambda a: np.float32(np.max(a)) if a.size else np.float32(np.nan), 'agg': np.max},
+        'mean_intensity': {'fn': lambda a: np.float32(np.nanmean(a)) if a.size else np.float32(np.nan), 'agg': np.mean},
+        'std_intensity': {'fn': lambda a: np.float32(np.nanstd(a)) if a.size else np.float32(np.nan), 'agg': np.mean},
+        'min_intensity': {'fn': lambda a: np.float32(np.nanmin(a)) if a.size else np.float32(np.nan), 'agg': np.min},
+        'max_intensity': {'fn': lambda a: np.float32(np.nanmax(a)) if a.size else np.float32(np.nan), 'agg': np.max},
     }
 
 class BasicStatsProcessor:

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/basic_stats_processor.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/basic_stats_processor.py
@@ -11,10 +11,10 @@ logger = logging.getLogger(__name__)
 
 def _column_fn_registry() -> Dict[str, Dict[str, Callable]]:
     return {
-        'mean_intensity': {'fn': lambda a: np.float32(np.nanmean(a)) if a.size else np.float32(np.nan), 'agg': np.mean},
-        'std_intensity': {'fn': lambda a: np.float32(np.nanstd(a)) if a.size else np.float32(np.nan), 'agg': np.mean},
-        'min_intensity': {'fn': lambda a: np.float32(np.nanmin(a)) if a.size else np.float32(np.nan), 'agg': np.min},
-        'max_intensity': {'fn': lambda a: np.float32(np.nanmax(a)) if a.size else np.float32(np.nan), 'agg': np.max},
+        'mean_intensity': {'fn': lambda a: np.float32(np.nanmean(a)) if a.size else np.float32(np.nan), 'agg': np.nanmean},
+        'std_intensity': {'fn': lambda a: np.float32(np.nanstd(a)) if a.size else np.float32(np.nan), 'agg': np.nanmean},
+        'min_intensity': {'fn': lambda a: np.float32(np.nanmin(a)) if a.size else np.float32(np.nan), 'agg': np.nanmin},
+        'max_intensity': {'fn': lambda a: np.float32(np.nanmax(a)) if a.size else np.float32(np.nan), 'agg': np.nanmax},
     }
 
 class BasicStatsProcessor:

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/histogram_processor.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/histogram_processor.py
@@ -25,10 +25,10 @@ def safe_hist_range(x: da.Array | np.ndarray) -> Tuple[float, float, float]:
     """
     # compute min/max without pulling full arrays where possible
     if isinstance(x, da.Array):
-        min_val, max_val = da.compute(x.min(), x.max())
+        min_val, max_val = da.compute(x.nanmin(), x.nanmax())
         min_val, max_val = np.float64(min_val), np.float64(max_val)  # cast to float64 to avoid overflows
     else:
-        min_val, max_val = np.float64(np.min(x)), np.float64(np.max(x))
+        min_val, max_val = np.float64(np.nanmin(x)), np.float64(np.nanmax(x))
 
     # If the underlying data type is uint8, set the minimum to 0 so we
     # use the full 0..255 bin range for display/processing. This ensures

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/histogram_processor.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/histogram_processor.py
@@ -10,11 +10,9 @@ from pixel_patrol_base.core.record import Record
 from pixel_patrol_base.core.specs import RecordSpec
 from pixel_patrol_base.utils.array_utils import calculate_sliced_stats
 from pixel_patrol_base.core.feature_schema import validate_processor_output
+from pixel_patrol_base.config import HISTOGRAM_BINS
 
 logger = logging.getLogger(__name__)
-
-HISTOGRAM_BINS = 256
-
 
 def safe_hist_range(x: da.Array | np.ndarray) -> Tuple[float, float, float]:
     """
@@ -25,10 +23,14 @@ def safe_hist_range(x: da.Array | np.ndarray) -> Tuple[float, float, float]:
     """
     # compute min/max without pulling full arrays where possible
     if isinstance(x, da.Array):
-        min_val, max_val = da.compute(x.nanmin(), x.nanmax())
+        min_val, max_val = da.compute(da.nanmin(x), da.nanmax(x))
         min_val, max_val = np.float64(min_val), np.float64(max_val)  # cast to float64 to avoid overflows
     else:
         min_val, max_val = np.float64(np.nanmin(x)), np.float64(np.nanmax(x))
+
+    # catching the all-NaN array:
+    if not np.isfinite(min_val) or not np.isfinite(max_val):
+        return 0.0, 0.0, 1.0
 
     # If the underlying data type is uint8, set the minimum to 0 so we
     # use the full 0..255 bin range for display/processing. This ensures
@@ -60,11 +62,18 @@ def _hist_func(arr: da.Array | np.ndarray, bins: int) -> Dict[str, Any]:
     """
     Calculates a histogram on a Dask or NumPy array.
     For Dask arrays this uses Dask's histogram to avoid pulling the full chunk into memory.
+    NaNs are excluded from bin counts and tallied separately in nan_count.
     Returns a dict with:
       - "counts": numpy.ndarray (dtype=np.int64)
       - "min": Python float
       - "max": Python float
+      - "nan_count": int
     """
+    if isinstance(arr, da.Array):
+        nan_count = int(da.compute(da.sum(da.isnull(arr)))[0])
+    else:
+        nan_count = int(np.sum(np.isnan(arr)))
+
     # Compute min/max and adjusted upper bound with shared helper
     min_val, max_val, max_adj_val = safe_hist_range(arr)
 
@@ -78,7 +87,7 @@ def _hist_func(arr: da.Array | np.ndarray, bins: int) -> Dict[str, Any]:
         counts_np, _ = np.histogram(arr, bins=bins, range=(min_val, max_adj_val))
         counts_arr = np.asarray(counts_np, dtype=np.int64)
 
-    return {"counts": counts_arr, "min": min_val, "max": max_val}
+    return {"counts": counts_arr, "min": min_val, "max": max_val, "nan_count": nan_count}
 
 
 class HistogramProcessor:
@@ -95,11 +104,13 @@ class HistogramProcessor:
         "histogram_counts": (np.int32, HISTOGRAM_BINS),
         "histogram_min": np.float32,
         "histogram_max": np.float32,
+        "histogram_nan_count": np.uint32,
     }
     OUTPUT_SCHEMA_PATTERNS = [
         (r"^histogram_counts_.*$", (np.int32, HISTOGRAM_BINS)),
         (r"^histogram_min_.*$", np.float32),
         (r"^histogram_max_.*$", np.float32),
+        (r"^histogram_nan_count_.*$", np.uint32),
     ]
 
     def run(self, art: Record) -> ProcessResult:
@@ -112,7 +123,12 @@ class HistogramProcessor:
 
         # For empty arrays, return zeroed counts and default 0..255 range so the image is visible in comparisons
         if getattr(data, "size", 0) == 0:
-            return {"histogram_counts": np.array([]), "histogram_min": 0.0, "histogram_max": 0.0}
+            return {
+                "histogram_counts":    np.zeros(HISTOGRAM_BINS, dtype=np.int32),
+                "histogram_min":       0.0,
+                "histogram_max":       0.0,
+                "histogram_nan_count": np.uint32(0),
+            }
 
         # Metric functions operate on 2D numpy planes provided by apply_gufunc.
         # To avoid calling _hist_func three times per plane, compute once and reuse
@@ -134,10 +150,15 @@ class HistogramProcessor:
         def _max_fn(plane: np.ndarray):
             return _compute_once(plane)["max"]
 
+        def _nan_count_fn(plane: np.ndarray):
+            return _compute_once(plane)["nan_count"]
+
+
         metrics = {
             "histogram_counts": _counts_fn,
             "histogram_min": _min_fn,
             "histogram_max": _max_fn,
+            "histogram_nan_count": _nan_count_fn,
         }
 
         # Aggregators: sum counts per-bin, and take min/max for boundaries
@@ -145,6 +166,7 @@ class HistogramProcessor:
             "histogram_counts": np.sum,
             "histogram_min": np.min,
             "histogram_max": np.max,
+            "histogram_nan_count": np.sum,
         }
 
         result = calculate_sliced_stats(data, dim_order, metrics, aggregators)

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/thumbnail_processor.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/plugins/processors/thumbnail_processor.py
@@ -115,6 +115,9 @@ def _generate_thumbnail(
     arr = da_array.copy()
     if arr.dtype == bool:
         arr = arr.astype(np.float32)
+    elif np.issubdtype(arr.dtype, np.floating):
+        # replace NaNs with zeros to avoid RuntimeWarnings of dask
+        arr = da.where(da.isnull(arr), 0.0, arr)
 
     is_rgb = color_dim is not None
 

--- a/packages/pixel-patrol-base/tests/plugins/processors/test_basic_stats_processor.py
+++ b/packages/pixel-patrol-base/tests/plugins/processors/test_basic_stats_processor.py
@@ -168,3 +168,17 @@ class TestBasicStatsProcessor:
         assert result["max_intensity"] == pytest.approx(42.0, rel=1e-5)
         assert result["std_intensity"] == pytest.approx(0.0, rel=1e-5)
 
+    def test_basic_stats_image_with_nan(self):
+        """Test basic stats on single pixel image."""
+        data = np.array([[0, 1, 2, 3, 4, np.nan]], dtype=np.float32)
+        dask_data = da.from_array(data, chunks=(1, 1))
+
+        record = record_from(dask_data, {"dim_order": "YX"})
+        processor = BasicStatsProcessor()
+
+        result = processor.run(record)
+
+        assert result["mean_intensity"] == pytest.approx(2, rel=1e-5)
+        assert result["min_intensity"] == pytest.approx(0, rel=1e-5)
+        assert result["max_intensity"] == pytest.approx(4, rel=1e-5)
+        assert result["std_intensity"] == pytest.approx(2**0.5, rel=1e-5)

--- a/packages/pixel-patrol-base/tests/plugins/processors/test_basic_stats_processor.py
+++ b/packages/pixel-patrol-base/tests/plugins/processors/test_basic_stats_processor.py
@@ -169,7 +169,7 @@ class TestBasicStatsProcessor:
         assert result["std_intensity"] == pytest.approx(0.0, rel=1e-5)
 
     def test_basic_stats_image_with_nan(self):
-        """Test basic stats on single pixel image."""
+        """Test basic stats on image with NaN values — NaNs are ignored in all statistics."""
         data = np.array([[0, 1, 2, 3, 4, np.nan]], dtype=np.float32)
         dask_data = da.from_array(data, chunks=(1, 1))
 
@@ -182,3 +182,23 @@ class TestBasicStatsProcessor:
         assert result["min_intensity"] == pytest.approx(0, rel=1e-5)
         assert result["max_intensity"] == pytest.approx(4, rel=1e-5)
         assert result["std_intensity"] == pytest.approx(2**0.5, rel=1e-5)
+
+    def test_basic_stats_nan_slice_does_not_poison_aggregate(self):
+        """If one time slice is entirely NaN, the aggregate must reflect only the valid slice."""
+        data = np.array([
+            [[1., 2.], [3., 4.]],  # t0: mean=2.5, min=1, max=4
+            [[np.nan, np.nan], [np.nan, np.nan]],  # t1: all NaN
+        ], dtype=np.float32)
+        dask_data = da.from_array(data, chunks=(1, 2, 2))
+
+        record = record_from(dask_data, {"dim_order": "TYX"})
+        result = BasicStatsProcessor().run(record)
+
+        # Per-slice: t0 is valid, t1 is all-NaN
+        assert result["mean_intensity_t0"] == pytest.approx(2.5, rel=1e-5)
+        assert np.isnan(result["mean_intensity_t1"])
+
+        # Aggregate: all-NaN slice must not poison the result
+        assert result["mean_intensity"] == pytest.approx(2.5, rel=1e-5)
+        assert result["min_intensity"] == pytest.approx(1.0, rel=1e-5)
+        assert result["max_intensity"] == pytest.approx(4.0, rel=1e-5)

--- a/packages/pixel-patrol-base/tests/plugins/processors/test_histogram_processor.py
+++ b/packages/pixel-patrol-base/tests/plugins/processors/test_histogram_processor.py
@@ -238,15 +238,17 @@ class TestHistogramProcessor:
         assert result["histogram_max"] == pytest.approx(3000.0, rel=1e-5)
 
     def test_histogram_with_nan_dask(self):
-        data = np.array([[0., 1., 2.], [np.nan, float("nan"), 3.]], dtype=np.float32)
+        data = np.array([[0., 1., 2., 1.], [np.nan, np.nan, float("nan"), 255.]], dtype=np.float32)
         dask_data = da.from_array(data, chunks=(2, 3))
         record = record_from(dask_data, {"dim_order": "YX"})
         processor = HistogramProcessor()
 
         result = processor.run(record)
 
-        # Should produce 256-bin histogram
         assert "histogram_counts" in result
         assert len(result["histogram_counts"]) == 256
-        assert result["histogram_min"] == pytest.approx(0.0, rel=1e-5)
-        assert result["histogram_max"] == pytest.approx(3., rel=1e-5)
+        assert result["histogram_min"] == pytest.approx(0., rel=1e-5)
+        assert result["histogram_max"] == pytest.approx(255., rel=1e-5)
+        assert list(result["histogram_counts"][0:3]) == [1, 2, 1]
+        assert result["histogram_counts"][255] == 1
+

--- a/packages/pixel-patrol-base/tests/plugins/processors/test_histogram_processor.py
+++ b/packages/pixel-patrol-base/tests/plugins/processors/test_histogram_processor.py
@@ -237,3 +237,16 @@ class TestHistogramProcessor:
         # For integer types, max_adj = max + 1, but histogram_max should be the actual max
         assert result["histogram_max"] == pytest.approx(3000.0, rel=1e-5)
 
+    def test_histogram_with_nan_dask(self):
+        data = np.array([[0., 1., 2.], [np.nan, float("nan"), 3.]], dtype=np.float32)
+        dask_data = da.from_array(data, chunks=(2, 3))
+        record = record_from(dask_data, {"dim_order": "YX"})
+        processor = HistogramProcessor()
+
+        result = processor.run(record)
+
+        # Should produce 256-bin histogram
+        assert "histogram_counts" in result
+        assert len(result["histogram_counts"]) == 256
+        assert result["histogram_min"] == pytest.approx(0.0, rel=1e-5)
+        assert result["histogram_max"] == pytest.approx(3., rel=1e-5)

--- a/packages/pixel-patrol-base/tests/plugins/processors/test_histogram_processor.py
+++ b/packages/pixel-patrol-base/tests/plugins/processors/test_histogram_processor.py
@@ -4,7 +4,7 @@ import pytest
 
 from pixel_patrol_base.core.record import record_from
 from pixel_patrol_base.plugins.processors.histogram_processor import HistogramProcessor
-
+from pixel_patrol_base.config import HISTOGRAM_BINS
 
 class TestHistogramProcessor:
     """Test suite for HistogramProcessor to verify correct calculation of histograms."""
@@ -25,8 +25,8 @@ class TestHistogramProcessor:
         assert "histogram_min" in result
         assert "histogram_max" in result
         
-        # Verify histogram_counts is a list of 256 elements
-        assert len(result["histogram_counts"]) == 256
+        # Verify histogram_counts is a list of HISTOGRAM_BINS (256) elements
+        assert len(result["histogram_counts"]) == HISTOGRAM_BINS
         assert isinstance(result["histogram_counts"], np.ndarray)
         
         # Verify min and max
@@ -63,7 +63,7 @@ class TestHistogramProcessor:
         # All pixels have value 42
         assert result["histogram_counts"][42] == 100
         # All other bins should be 0
-        for i in range(256):
+        for i in range(HISTOGRAM_BINS):
             if i != 42:
                 assert result["histogram_counts"][i] == 0
         
@@ -85,7 +85,7 @@ class TestHistogramProcessor:
         # for uint8, histogram should use full 0-255 range
         assert result["histogram_min"] == 0.0
         assert result["histogram_max"] == 255.0
-        assert len(result["histogram_counts"]) == 256
+        assert len(result["histogram_counts"]) == HISTOGRAM_BINS
 
     def test_histogram_with_time_dimension(self):
         """Test histogram on image with time dimension."""
@@ -115,8 +115,8 @@ class TestHistogramProcessor:
         assert "histogram_max_t1" in result
         
         # Verify per-time histogram counts
-        assert len(result["histogram_counts_t0"]) == 256
-        assert len(result["histogram_counts_t1"]) == 256
+        assert len(result["histogram_counts_t0"]) == HISTOGRAM_BINS
+        assert len(result["histogram_counts_t1"]) == HISTOGRAM_BINS
         
         # Each time slice has 9 pixels
         assert sum(result["histogram_counts_t0"]) == 9
@@ -154,7 +154,7 @@ class TestHistogramProcessor:
     def test_histogram_with_multiple_dimensions(self):
         """Test histogram on image with T, C, Z dimensions."""
         # Create a TCZYX image: 2 time, 2 channels, 2 z-slices, 2x2 spatial
-        data = np.random.randint(0, 256, size=(2, 2, 2, 2, 2), dtype=np.uint8)
+        data = np.random.randint(0, HISTOGRAM_BINS, size=(2, 2, 2, 2, 2), dtype=np.uint8)
         dask_data = da.from_array(data, chunks=(1, 1, 1, 2, 2))
         
         record = record_from(dask_data, {"dim_order": "TCZYX"})
@@ -171,29 +171,26 @@ class TestHistogramProcessor:
         assert any("histogram_counts_c" in key for key in result.keys())
         assert any("histogram_counts_z" in key for key in result.keys())
         
-        # Verify all histogram_counts lists have 256 elements
+        # Verify all histogram_counts lists have HISTOGRAM_BINS (256) elements
         for key, value in result.items():
             if key.startswith("histogram_counts"):
-                assert len(value) == 256
+                assert len(value) == HISTOGRAM_BINS
                 assert isinstance(value, np.ndarray) # TODO: FIXME: expected list, got array 'cause function casts to numpy array
 
     def test_histogram_empty_image(self):
-        """Test histogram on empty image."""
+        """Empty array: zero-filled 256-bin histogram, nan_count=0.
+        Distinguishable from all-NaN by nan_count == 0."""
         data = np.array([[]], dtype=np.uint8)
         dask_data = da.from_array(data, chunks=(1, 1))
-        
         record = record_from(dask_data, {"dim_order": "YX"})
-        processor = HistogramProcessor()
-        
-        result = processor.run(record)
-        
-        # Should handle empty arrays gracefully
-        assert "histogram_counts" in result
-        assert len(result["histogram_counts"]) == 0
-        # All counts should be zero
-        assert all(count == 0 for count in result["histogram_counts"])
+        result = HistogramProcessor().run(record)
+
+        assert len(result["histogram_counts"]) == HISTOGRAM_BINS
+        assert sum(result["histogram_counts"]) == 0
         assert result["histogram_min"] == 0.0
         assert result["histogram_max"] == 0.0
+        assert result["histogram_nan_count"] == 0
+
 
     def test_histogram_float_image(self):
         """Test histogram on float image (non-uint8)."""
@@ -206,9 +203,9 @@ class TestHistogramProcessor:
         
         result = processor.run(record)
         
-        # Should still produce 256-bin histogram
+        # Should still produce HISTOGRAM_BINS (256)-bin histogram
         assert "histogram_counts" in result
-        assert len(result["histogram_counts"]) == 256
+        assert len(result["histogram_counts"]) == HISTOGRAM_BINS
         
         # Min and max should reflect actual data range
         assert result["histogram_min"] == pytest.approx(0.0, rel=1e-5)
@@ -228,9 +225,9 @@ class TestHistogramProcessor:
         
         result = processor.run(record)
         
-        # Should produce 256-bin histogram
+        # Should produce HISTOGRAM_BINS (256-bin) histogram
         assert "histogram_counts" in result
-        assert len(result["histogram_counts"]) == 256
+        assert len(result["histogram_counts"]) == HISTOGRAM_BINS
         
         # Min and max should reflect actual data range
         assert result["histogram_min"] == pytest.approx(0.0, rel=1e-5)
@@ -238,17 +235,30 @@ class TestHistogramProcessor:
         assert result["histogram_max"] == pytest.approx(3000.0, rel=1e-5)
 
     def test_histogram_with_nan_dask(self):
+        """Partial NaN: valid pixels binned correctly, NaNs tallied in nan_count."""
         data = np.array([[0., 1., 2., 1.], [np.nan, np.nan, float("nan"), 255.]], dtype=np.float32)
         dask_data = da.from_array(data, chunks=(2, 3))
         record = record_from(dask_data, {"dim_order": "YX"})
-        processor = HistogramProcessor()
+        result = HistogramProcessor().run(record)
 
-        result = processor.run(record)
-
-        assert "histogram_counts" in result
-        assert len(result["histogram_counts"]) == 256
+        assert len(result["histogram_counts"]) == HISTOGRAM_BINS
         assert result["histogram_min"] == pytest.approx(0., rel=1e-5)
         assert result["histogram_max"] == pytest.approx(255., rel=1e-5)
         assert list(result["histogram_counts"][0:3]) == [1, 2, 1]
         assert result["histogram_counts"][255] == 1
+        assert result["histogram_nan_count"] == 3
+
+    def test_histogram_all_nan_image(self):
+        """All-NaN array: zero bin counts, nan_count == total pixels.
+        Distinguishable from empty array by nan_count > 0."""
+        data = np.full((10, 10), np.nan, dtype=np.float32)
+        dask_data = da.from_array(data, chunks=(5, 5))
+        record = record_from(dask_data, {"dim_order": "YX"})
+        result = HistogramProcessor().run(record)
+
+        assert len(result["histogram_counts"]) == HISTOGRAM_BINS
+        assert sum(result["histogram_counts"]) == 0
+        assert np.isfinite(result["histogram_min"])
+        assert np.isfinite(result["histogram_max"])
+        assert result["histogram_nan_count"] == 100
 

--- a/packages/pixel-patrol-base/tests/plugins/processors/test_thumbnail_processor.py
+++ b/packages/pixel-patrol-base/tests/plugins/processors/test_thumbnail_processor.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import dask.array as da
 import pytest
@@ -287,3 +289,12 @@ class TestThumbnailProcessor:
         data = np.zeros((10, 10), dtype=np.uint16)
         result = self._run(data, "YX")
         assert result["thumbnail_dtype"] == "uint16"
+
+    # ------------------------------------------------------------------
+    # NaN handling
+    # ------------------------------------------------------------------
+    def test_nan_handling(self):
+        data = np.array([[0, 1, 2, np.nan]], dtype=np.float32)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self._run(data, "YX")


### PR DESCRIPTION
add a test and fix HistogramProcessor, BasicStatsProcessor, and ThumbnailProcessors''s handling of images that contain NaN values