### PR TITLE
build-viewer-html: offline + CDN single-file viewer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ api.view(project)
 Send the `.parquet` file and open it in the [hosted viewer](https://pixelpatrol.app/viewer/) - no installation needed. Or build a self-contained static viewer:
 
 ```bash
-pixel-patrol build-viewer-html -o viewer.html
+pixel-patrol build-viewer-html -o viewer.html             # light (~7 MB), loads DuckDB WASM from a CDN
+pixel-patrol build-viewer-html -o viewer.html --offline   # fully self-contained, works with no network
 ```
 
 > **Note:** The static viewer may not load very large parquet files (e.g. 5 GB+). Use `pixel-patrol view` for large reports.

--- a/docs/viewer.md
+++ b/docs/viewer.md
@@ -23,10 +23,21 @@ Open [pixelpatrol.app/viewer](https://pixelpatrol.app/viewer/) and drag and drop
 
 **From a built static viewer:**
 
-Build a self-contained viewer file and open it alongside your parquet:
+Build a viewer file and open it alongside your parquet:
 
 ```bash
 pixel-patrol build-viewer-html -o viewer.html
+```
+
+By default this writes a **light** file (~7 MB): it inlines the viewer's own
+JS/CSS but loads the large DuckDB WASM engine from a CDN (jsdelivr), so it works
+for any installed version and needs an internet connection only for DuckDB.
+
+For a fully **self-contained** file that works with no network access, pass
+`--offline` (this inlines all JS/CSS/WASM too, producing a large ~50 MB+ file):
+
+```bash
+pixel-patrol build-viewer-html -o viewer.html --offline
 ```
 
 Open `viewer.html` in any browser and load your parquet from there. To share with someone, send them both files. See the [privacy policy](privacy.md) for what's included in the parquet file before sharing it.

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/api.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/api.py
@@ -166,33 +166,51 @@ def view(
     )
 
 
-def build_viewer(output: Union[str, Path]) -> Path:
+def build_viewer(
+    output: Union[str, Path],
+    offline: bool = False,
+    base_url: Optional[str] = None,
+) -> Path:
     """
     Build a static viewer from the installed web viewer bundle.
 
-    If OUTPUT ends in .html or .htm, writes a single self-contained HTML file
-    with all JS/CSS/extensions inlined - share it alongside your .parquet file.
+    If OUTPUT ends in .html or .htm, writes a single HTML file - share it
+    alongside your .parquet file. By default this is a light (~7 MB) file that
+    inlines the app bundle but loads DuckDB WASM from a CDN; it works for any
+    installed version and needs a network connection only for DuckDB.
+
+    Pass offline=True to inline all JS/CSS/WASM into a large self-contained file
+    that works with no network access. Pass base_url to instead reference the
+    app bundle from a host (e.g. the hosted viewer for a matching released
+    version) for a tiny file - the deployed bundle must be the exact same build.
 
     Otherwise OUTPUT is treated as a directory and a GitHub Pages-style site
     is written there (index.html + assets + extensions folders) - deploy to
     any static host and open with a ?data= URL pointing to your parquet.
+    (offline / base_url do not apply to the directory build.)
 
     Args:
         output: Path to a .html file or a directory.
+        offline: For single-file builds, inline all dependencies (incl. WASM).
+        base_url: For single-file builds, reference the app bundle from this
+            URL instead of inlining it. Ignored when offline=True.
 
     Returns:
         Path to the written file or directory.
 
     Examples:
         >>> from pixel_patrol_base import api
-        >>> api.build_viewer("viewer.html")        # single file
+        >>> api.build_viewer("viewer.html")                 # light single file
+        >>> api.build_viewer("viewer.html", offline=True)   # self-contained
+        >>> api.build_viewer("viewer.html",                 # tiny, hosted bundle
+        ...     base_url="https://ida-mdc.github.io/pixel-patrol/viewer/")
         # OR
-        >>> api.build_viewer("gh-pages-out/")      # site folder
+        >>> api.build_viewer("gh-pages-out/")               # site folder
     """
 
     output = Path(output)
     if output.suffix.lower() in {".html", ".htm"}:
-        out = build_single_file_viewer_html(output)
+        out = build_single_file_viewer_html(output, offline=offline, base_url=base_url)
         logger.info("Single-file viewer written to: '%s'", out)
     else:
         out = build_github_pages_site(output)

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/api.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/api.py
@@ -169,7 +169,6 @@ def view(
 def build_viewer(
     output: Union[str, Path],
     offline: bool = False,
-    base_url: Optional[str] = None,
 ) -> Path:
     """
     Build a static viewer from the installed web viewer bundle.
@@ -180,20 +179,16 @@ def build_viewer(
     installed version and needs a network connection only for DuckDB.
 
     Pass offline=True to inline all JS/CSS/WASM into a large self-contained file
-    that works with no network access. Pass base_url to instead reference the
-    app bundle from a host (e.g. the hosted viewer for a matching released
-    version) for a tiny file - the deployed bundle must be the exact same build.
+    that works with no network access.
 
     Otherwise OUTPUT is treated as a directory and a GitHub Pages-style site
     is written there (index.html + assets + extensions folders) - deploy to
     any static host and open with a ?data= URL pointing to your parquet.
-    (offline / base_url do not apply to the directory build.)
+    (offline does not apply to the directory build.)
 
     Args:
         output: Path to a .html file or a directory.
         offline: For single-file builds, inline all dependencies (incl. WASM).
-        base_url: For single-file builds, reference the app bundle from this
-            URL instead of inlining it. Ignored when offline=True.
 
     Returns:
         Path to the written file or directory.
@@ -202,15 +197,13 @@ def build_viewer(
         >>> from pixel_patrol_base import api
         >>> api.build_viewer("viewer.html")                 # light single file
         >>> api.build_viewer("viewer.html", offline=True)   # self-contained
-        >>> api.build_viewer("viewer.html",                 # tiny, hosted bundle
-        ...     base_url="https://ida-mdc.github.io/pixel-patrol/viewer/")
         # OR
         >>> api.build_viewer("gh-pages-out/")               # site folder
     """
 
     output = Path(output)
     if output.suffix.lower() in {".html", ".htm"}:
-        out = build_single_file_viewer_html(output, offline=offline, base_url=base_url)
+        out = build_single_file_viewer_html(output, offline=offline)
         logger.info("Single-file viewer written to: '%s'", out)
     else:
         out = build_github_pages_site(output)

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/cli.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/cli.py
@@ -12,6 +12,7 @@ from pixel_patrol_base.api import (
 )
 
 from pixel_patrol_base.launch_server import serve_launch
+from pixel_patrol_base.viewer_pages import VIEWER_CDN_BASE
 
 
 @click.group()
@@ -226,16 +227,31 @@ def view(parquet_file, port, no_browser,
     "-o",
     type=click.Path(exists=False, file_okay=True, dir_okay=True, writable=True, path_type=Path),
     required=True,
-    help='Output path. Use .html/.htm for a single self-contained file, '
+    help='Output path. Use .html/.htm for a single HTML file, '
          'or a directory for a GitHub Pages-style site folder.')
-def build_viewer_html(output: Path):
+@click.option(
+    "--offline/--no-offline",
+    default=False,
+    help='For single-file (.html) output, inline EVERYTHING incl. DuckDB WASM '
+         'for a fully self-contained (~50 MB+) file that needs no network. '
+         'Default: inline the app bundle but load DuckDB WASM from a CDN (~7 MB).')
+@click.option(
+    "--base-url",
+    default=None,
+    help='For single-file (.html) output, reference the app bundle from this '
+         'URL instead of inlining it, for a tiny file. The host must serve the '
+         f'exact same build (e.g. {VIEWER_CDN_BASE} '
+         'for a matching released version). Ignored with --offline.')
+def build_viewer_html(output: Path, offline: bool, base_url: str | None):
     """
     Build static viewer output from the installed web viewer bundle.
 
-    If OUTPUT ends in .html/.htm, writes a single self-contained HTML file.
+    If OUTPUT ends in .html/.htm, writes a single HTML file (light by default;
+    pass --offline to inline all dependencies, or --base-url to reference the
+    app bundle from a host).
     Otherwise, writes a GitHub Pages-style site folder (index.html + assets + extensions).
     """
-    api_build_viewer(output)
+    api_build_viewer(output, offline=offline, base_url=base_url)
 
 
 @cli.command()

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/cli.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/cli.py
@@ -12,7 +12,6 @@ from pixel_patrol_base.api import (
 )
 
 from pixel_patrol_base.launch_server import serve_launch
-from pixel_patrol_base.viewer_pages import VIEWER_CDN_BASE
 
 
 @click.group()
@@ -235,23 +234,15 @@ def view(parquet_file, port, no_browser,
     help='For single-file (.html) output, inline EVERYTHING incl. DuckDB WASM '
          'for a fully self-contained (~50 MB+) file that needs no network. '
          'Default: inline the app bundle but load DuckDB WASM from a CDN (~7 MB).')
-@click.option(
-    "--base-url",
-    default=None,
-    help='For single-file (.html) output, reference the app bundle from this '
-         'URL instead of inlining it, for a tiny file. The host must serve the '
-         f'exact same build (e.g. {VIEWER_CDN_BASE} '
-         'for a matching released version). Ignored with --offline.')
-def build_viewer_html(output: Path, offline: bool, base_url: str | None):
+def build_viewer_html(output: Path, offline: bool):
     """
     Build static viewer output from the installed web viewer bundle.
 
     If OUTPUT ends in .html/.htm, writes a single HTML file (light by default;
-    pass --offline to inline all dependencies, or --base-url to reference the
-    app bundle from a host).
+    pass --offline to inline all dependencies).
     Otherwise, writes a GitHub Pages-style site folder (index.html + assets + extensions).
     """
-    api_build_viewer(output, offline=offline, base_url=base_url)
+    api_build_viewer(output, offline=offline)
 
 
 @cli.command()

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_pages.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_pages.py
@@ -180,7 +180,7 @@ def _rewrite_local_refs_to_cdn(html: str, base_url: str) -> str:
         url = match.group("url")
         if re.match(r"^(?:[a-zA-Z][a-zA-Z0-9+.-]*:|//|#)", url):
             return match.group(0)
-        rel = url.lstrip("./").lstrip("/")
+        rel = url.removeprefix("./").lstrip("/")
         return f'{attr}="{base}{rel}"'
 
     return re.sub(r'(?P<attr>(?:src|href))="(?P<url>[^"]+)"', repl, html)

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_pages.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_pages.py
@@ -9,6 +9,17 @@ from pathlib import Path
 
 from pixel_patrol_base.viewer_server import _discover_installed_extensions, find_viewer_dist, resolve_extension_plugins
 
+# Host that serves the deployed viewer bundle, and the single source for the
+# value suggested in the build-viewer-html --base-url help. That option references
+# the app's JS/CSS (and images) from a host instead of inlining them. Asset file
+# names are content-hashed, so the host must serve the exact same build (i.e. a
+# matching released version) or the references 404.
+VIEWER_CDN_BASE = "https://ida-mdc.github.io/pixel-patrol/viewer/"
+
+# Fallback used only if the build metadata is missing from the viewer bundle
+# (e.g. an older bundle built before pp_build_meta.json was emitted).
+_DEFAULT_DUCKDB_WASM_VERSION = "1.32.0"
+
 
 def _safe_name(name: str) -> str:
     safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", name).strip("-")
@@ -42,12 +53,18 @@ def _inject_extension_urls(index_html: Path, urls: list[str]) -> None:
     index_html.write_text(html, encoding="utf-8")
 
 
-def _inline_local_assets(html: str, dist_dir: Path) -> str:
+def _inline_local_assets(html: str, dist_dir: Path, exclude_names: frozenset[str] = frozenset()) -> str:
+    """Inline local script/style/media assets as data URLs.
+
+    Assets whose file name is in exclude_names are left as-is (their references
+    are not rewritten), so they can instead be served from a CDN - used to keep
+    the large DuckDB WASM/worker out of the file while inlining everything else.
+    """
     asset_data_url_map: dict[str, str] = {}
     assets_dir = dist_dir / "assets"
     if assets_dir.is_dir():
         for asset_path in assets_dir.rglob("*"):
-            if not asset_path.is_file():
+            if not asset_path.is_file() or asset_path.name in exclude_names:
                 continue
             rel = asset_path.relative_to(dist_dir).as_posix()
             name = asset_path.name
@@ -114,6 +131,59 @@ def _inline_local_assets(html: str, dist_dir: Path) -> str:
     )
     html = re.sub(r'(?P<attr>(?:src|href))="(?P<url>[^"]+)"', repl_media, html)
     return html
+
+
+def _read_duckdb_wasm_version(dist_dir: Path) -> str:
+    meta_path = dist_dir / "pp_build_meta.json"
+    if meta_path.is_file():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            version = meta.get("duckdbWasmVersion")
+            if version:
+                return str(version)
+        except (ValueError, OSError):
+            pass
+    return _DEFAULT_DUCKDB_WASM_VERSION
+
+
+def _duckdb_asset_names(dist_dir: Path) -> frozenset[str]:
+    """File names of the bundled DuckDB WASM worker/module (hash-suffixed)."""
+    assets_dir = dist_dir / "assets"
+    if not assets_dir.is_dir():
+        return frozenset()
+    return frozenset(
+        p.name for p in assets_dir.glob("*")
+        if p.is_file() and "duckdb" in p.name.lower()
+    )
+
+
+def _duckdb_cdn_urls(dist_dir: Path) -> tuple[str, str]:
+    """jsdelivr URLs for the (single-thread mvp) DuckDB WASM worker and module."""
+    version = _read_duckdb_wasm_version(dist_dir)
+    base = f"https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@{version}/dist"
+    return (
+        f"{base}/duckdb-browser-mvp.worker.js",
+        f"{base}/duckdb-mvp.wasm",
+    )
+
+
+def _rewrite_local_refs_to_cdn(html: str, base_url: str) -> str:
+    """Point local src/href references at the deployed viewer host.
+
+    External URLs (http(s):, //, data:), in-page anchors (#) and other schemes
+    are left untouched - only bundle-relative paths are rewritten.
+    """
+    base = base_url.rstrip("/") + "/"
+
+    def repl(match: re.Match[str]) -> str:
+        attr = match.group("attr")
+        url = match.group("url")
+        if re.match(r"^(?:[a-zA-Z][a-zA-Z0-9+.-]*:|//|#)", url):
+            return match.group(0)
+        rel = url.lstrip("./").lstrip("/")
+        return f'{attr}="{base}{rel}"'
+
+    return re.sub(r'(?P<attr>(?:src|href))="(?P<url>[^"]+)"', repl, html)
 
 
 def _build_inline_extension_urls(extension_dirs: list[Path]) -> list[str]:
@@ -209,23 +279,63 @@ def build_github_pages_site(out_dir: str | Path = "gh-pages-site") -> Path:
     return out_dir
 
 
-def build_single_file_viewer_html(output_html: str | Path) -> Path:
+def build_single_file_viewer_html(
+    output_html: str | Path,
+    offline: bool = False,
+    base_url: str | None = None,
+) -> Path:
+    """Write a single-file HTML viewer.
+
+    Default (light): inline the app's JS/CSS/images, but load the large DuckDB
+    WASM from jsdelivr (and keep the existing Bootstrap CDN links). This is
+    ~7 MB instead of ~56 MB and works for any locally-built/installed version,
+    needing a network connection only for DuckDB. Extensions are inlined too.
+
+    offline=True: a fully self-contained file with all JS/CSS/WASM inlined as
+    data URLs - works without any network access but is large (~50 MB+).
+
+    base_url set: reference the app bundle (JS/CSS/images) from base_url instead
+    of inlining it, producing a tiny file. The bundle at base_url must be the
+    exact same build (asset file names are content-hashed), e.g. the hosted
+    viewer for a matching released version, or your own deployment. Ignored when
+    offline=True.
+    """
     output_html = Path(output_html).resolve()
     dist_dir = find_viewer_dist()
     index_html = dist_dir / "index.html"
     html = index_html.read_text(encoding="utf-8")
 
-    html = _inline_local_assets(html, dist_dir)
+    head_scripts = []
+    if offline:
+        # Everything inlined, including the DuckDB worker/wasm - no network.
+        html = _inline_local_assets(html, dist_dir)
+    else:
+        if base_url:
+            # App bundle served from a host; nothing local left to inline.
+            html = _rewrite_local_refs_to_cdn(html, base_url)
+        else:
+            # Inline the app bundle but keep DuckDB out of the file.
+            html = _inline_local_assets(html, dist_dir, exclude_names=_duckdb_asset_names(dist_dir))
+        worker_url, wasm_url = _duckdb_cdn_urls(dist_dir)
+        head_scripts.append(
+            "<script>\n"
+            f"window.__PP_DUCKDB_WORKER_URL = {json.dumps(worker_url)};\n"
+            f"window.__PP_DUCKDB_WASM_URL = {json.dumps(wasm_url)};\n"
+            "</script>\n"
+        )
+
     ext_urls = _build_inline_extension_urls(_discover_installed_extensions())
-    script = (
+    head_scripts.append(
         "<script>\n"
         f"window.__PP_EXTENSION_URLS = {json.dumps(ext_urls)};\n"
         "</script>\n"
     )
+
+    head = "".join(head_scripts)
     if "</head>" in html:
-        html = html.replace("</head>", script + "</head>", 1)
+        html = html.replace("</head>", head + "</head>", 1)
     else:
-        html = script + html
+        html = head + html
 
     output_html.parent.mkdir(parents=True, exist_ok=True)
     output_html.write_text(html, encoding="utf-8")

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_pages.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_pages.py
@@ -75,9 +75,12 @@ def _inline_local_assets(html: str, dist_dir: Path, exclude_names: frozenset[str
     def inline_js_asset_urls(code: str) -> str:
         # Preserve import.meta.url behavior by replacing runtime-resolved asset
         # paths (worker/wasm/etc.) with direct data URLs before embedding.
+        # Rolldown (Vite 8's bundler) minifies these as template literals
+        # (backticks) rather than quotes, so all three forms must be covered.
         for rel, data_url in asset_data_url_map.items():
             code = code.replace(f'"{rel}"', f'"{data_url}"')
             code = code.replace(f"'{rel}'", f"'{data_url}'")
+            code = code.replace(f'`{rel}`', f'`{data_url}`')
         return code
 
     def repl_script(match: re.Match[str]) -> str:

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_pages.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_pages.py
@@ -9,13 +9,6 @@ from pathlib import Path
 
 from pixel_patrol_base.viewer_server import _discover_installed_extensions, find_viewer_dist, resolve_extension_plugins
 
-# Host that serves the deployed viewer bundle, and the single source for the
-# value suggested in the build-viewer-html --base-url help. That option references
-# the app's JS/CSS (and images) from a host instead of inlining them. Asset file
-# names are content-hashed, so the host must serve the exact same build (i.e. a
-# matching released version) or the references 404.
-VIEWER_CDN_BASE = "https://ida-mdc.github.io/pixel-patrol/viewer/"
-
 # Fallback used only if the build metadata is missing from the viewer bundle
 # (e.g. an older bundle built before pp_build_meta.json was emitted).
 _DEFAULT_DUCKDB_WASM_VERSION = "1.32.0"
@@ -167,25 +160,6 @@ def _duckdb_cdn_urls(dist_dir: Path) -> tuple[str, str]:
     )
 
 
-def _rewrite_local_refs_to_cdn(html: str, base_url: str) -> str:
-    """Point local src/href references at the deployed viewer host.
-
-    External URLs (http(s):, //, data:), in-page anchors (#) and other schemes
-    are left untouched - only bundle-relative paths are rewritten.
-    """
-    base = base_url.rstrip("/") + "/"
-
-    def repl(match: re.Match[str]) -> str:
-        attr = match.group("attr")
-        url = match.group("url")
-        if re.match(r"^(?:[a-zA-Z][a-zA-Z0-9+.-]*:|//|#)", url):
-            return match.group(0)
-        rel = url.removeprefix("./").lstrip("/")
-        return f'{attr}="{base}{rel}"'
-
-    return re.sub(r'(?P<attr>(?:src|href))="(?P<url>[^"]+)"', repl, html)
-
-
 def _build_inline_extension_urls(extension_dirs: list[Path]) -> list[str]:
     urls: list[str] = []
     for ext_dir in extension_dirs:
@@ -282,7 +256,6 @@ def build_github_pages_site(out_dir: str | Path = "gh-pages-site") -> Path:
 def build_single_file_viewer_html(
     output_html: str | Path,
     offline: bool = False,
-    base_url: str | None = None,
 ) -> Path:
     """Write a single-file HTML viewer.
 
@@ -293,12 +266,6 @@ def build_single_file_viewer_html(
 
     offline=True: a fully self-contained file with all JS/CSS/WASM inlined as
     data URLs - works without any network access but is large (~50 MB+).
-
-    base_url set: reference the app bundle (JS/CSS/images) from base_url instead
-    of inlining it, producing a tiny file. The bundle at base_url must be the
-    exact same build (asset file names are content-hashed), e.g. the hosted
-    viewer for a matching released version, or your own deployment. Ignored when
-    offline=True.
     """
     output_html = Path(output_html).resolve()
     dist_dir = find_viewer_dist()
@@ -310,12 +277,8 @@ def build_single_file_viewer_html(
         # Everything inlined, including the DuckDB worker/wasm - no network.
         html = _inline_local_assets(html, dist_dir)
     else:
-        if base_url:
-            # App bundle served from a host; nothing local left to inline.
-            html = _rewrite_local_refs_to_cdn(html, base_url)
-        else:
-            # Inline the app bundle but keep DuckDB out of the file.
-            html = _inline_local_assets(html, dist_dir, exclude_names=_duckdb_asset_names(dist_dir))
+        # Inline the app bundle but keep DuckDB out of the file.
+        html = _inline_local_assets(html, dist_dir, exclude_names=_duckdb_asset_names(dist_dir))
         worker_url, wasm_url = _duckdb_cdn_urls(dist_dir)
         head_scripts.append(
             "<script>\n"

--- a/packages/pixel-patrol-base/tests/test_build_viewer_html.py
+++ b/packages/pixel-patrol-base/tests/test_build_viewer_html.py
@@ -11,11 +11,9 @@ import pytest
 
 from pixel_patrol_base import viewer_pages
 from pixel_patrol_base.viewer_pages import (
-    VIEWER_CDN_BASE,
     _DEFAULT_DUCKDB_WASM_VERSION,
     _duckdb_cdn_urls,
     _read_duckdb_wasm_version,
-    _rewrite_local_refs_to_cdn,
     build_single_file_viewer_html,
 )
 
@@ -89,21 +87,6 @@ class TestDuckdbCdnUrls:
         assert wasm.endswith("/duckdb-mvp.wasm")
 
 
-class TestRewriteLocalRefsToCdn:
-    def test_rewrites_relative_paths(self):
-        out = _rewrite_local_refs_to_cdn(INDEX_HTML, VIEWER_CDN_BASE)
-        base = VIEWER_CDN_BASE.rstrip("/") + "/"
-        assert f'{base}assets/index-ABC123.js' in out
-        assert f'{base}icon.png' in out
-        assert f'{base}logo.png' in out
-
-    def test_leaves_external_and_anchor_refs_untouched(self):
-        out = _rewrite_local_refs_to_cdn(INDEX_HTML, VIEWER_CDN_BASE)
-        assert 'href="https://cdn.jsdelivr.net/npm/bootstrap' in out
-        assert 'href="https://example.com/page"' in out
-        assert 'href="#anchor"' in out
-
-
 # ---------------------------------------------------------------------------
 # build_single_file_viewer_html
 # ---------------------------------------------------------------------------
@@ -138,29 +121,6 @@ class TestLightBuild:
         out = build_single_file_viewer_html(tmp_path / "v.html")
         html = out.read_text(encoding="utf-8")
         assert "cdn.jsdelivr.net/npm/bootstrap" in html
-
-
-class TestBaseUrlBuild:
-    """--base-url: reference the app bundle from a host instead of inlining."""
-
-    def test_references_app_bundle_from_base_url(self, patched, tmp_path):
-        out = build_single_file_viewer_html(tmp_path / "v.html", base_url=VIEWER_CDN_BASE)
-        html = out.read_text(encoding="utf-8")
-        assert f"{VIEWER_CDN_BASE.rstrip('/')}/assets/index-ABC123.js" in html
-        assert "console.log('app');" not in html  # not inlined
-
-    def test_still_uses_duckdb_cdn(self, patched, tmp_path):
-        out = build_single_file_viewer_html(tmp_path / "v.html", base_url="https://h/v/")
-        html = out.read_text(encoding="utf-8")
-        assert "window.__PP_DUCKDB_WORKER_URL =" in html
-
-    def test_offline_takes_precedence_over_base_url(self, patched, tmp_path):
-        out = build_single_file_viewer_html(
-            tmp_path / "v.html", offline=True, base_url=VIEWER_CDN_BASE
-        )
-        html = out.read_text(encoding="utf-8")
-        assert "ida-mdc.github.io" not in html
-        assert "console.log('app');" in html  # inlined, not referenced
 
 
 class TestOfflineBuild:

--- a/packages/pixel-patrol-base/tests/test_build_viewer_html.py
+++ b/packages/pixel-patrol-base/tests/test_build_viewer_html.py
@@ -40,11 +40,13 @@ def fake_dist(tmp_path: Path) -> Path:
     (dist / "index.html").write_text(INDEX_HTML, encoding="utf-8")
     (dist / "icon.png").write_bytes(b"icon")
     (dist / "logo.png").write_bytes(b"logo")
-    # App bundle references the DuckDB worker/wasm by their hashed names at runtime.
+    # App bundle references the DuckDB worker/wasm by their hashed names at
+    # runtime, as template literals - the form Rolldown (Vite 8's bundler)
+    # minifies these to.
     (assets / "index-ABC123.js").write_text(
         "console.log('app');\n"
-        'var w="./assets/duckdb-browser-mvp.worker-HASH.js";'
-        'var m="./assets/duckdb-mvp-HASH.wasm";',
+        "var w=`./assets/duckdb-browser-mvp.worker-HASH.js`;"
+        "var m=`./assets/duckdb-mvp-HASH.wasm`;",
         encoding="utf-8",
     )
     (assets / "index-DEF456.css").write_text("body{}", encoding="utf-8")
@@ -128,6 +130,12 @@ class TestOfflineBuild:
         out = build_single_file_viewer_html(tmp_path / "v.html", offline=True)
         html = out.read_text(encoding="utf-8")
         assert "console.log('app');" in html
+
+    def test_inlines_duckdb_wasm_referenced_as_template_literal(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html", offline=True)
+        html = out.read_text(encoding="utf-8")
+        assert "duckdb-mvp-HASH.wasm" not in html  # rewritten to a data URL
+        assert "data:application/wasm;base64," in html  # the actual bytes are embedded
 
     def test_no_cdn_app_bundle_or_duckdb_globals(self, patched, tmp_path):
         out = build_single_file_viewer_html(tmp_path / "v.html", offline=True)

--- a/packages/pixel-patrol-base/tests/test_build_viewer_html.py
+++ b/packages/pixel-patrol-base/tests/test_build_viewer_html.py
@@ -1,0 +1,182 @@
+"""
+Tests for the single-file static viewer builder (viewer_pages).
+
+Covers the light (URL-referenced, default) vs offline (fully inlined) modes of
+build_single_file_viewer_html and the small helpers they rely on.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from pixel_patrol_base import viewer_pages
+from pixel_patrol_base.viewer_pages import (
+    VIEWER_CDN_BASE,
+    _DEFAULT_DUCKDB_WASM_VERSION,
+    _duckdb_cdn_urls,
+    _read_duckdb_wasm_version,
+    _rewrite_local_refs_to_cdn,
+    build_single_file_viewer_html,
+)
+
+
+INDEX_HTML = """<!DOCTYPE html>
+<html><head>
+  <link rel="icon" href="./icon.png"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
+  <script type="module" crossorigin src="./assets/index-ABC123.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/index-DEF456.css">
+</head><body>
+  <img src="./logo.png"/>
+  <a href="#anchor">jump</a>
+  <a href="https://example.com/page">external</a>
+</body></html>
+"""
+
+
+@pytest.fixture
+def fake_dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "viewer_dist"
+    assets = dist / "assets"
+    assets.mkdir(parents=True)
+    (dist / "index.html").write_text(INDEX_HTML, encoding="utf-8")
+    (dist / "icon.png").write_bytes(b"icon")
+    (dist / "logo.png").write_bytes(b"logo")
+    # App bundle references the DuckDB worker/wasm by their hashed names at runtime.
+    (assets / "index-ABC123.js").write_text(
+        "console.log('app');\n"
+        'var w="./assets/duckdb-browser-mvp.worker-HASH.js";'
+        'var m="./assets/duckdb-mvp-HASH.wasm";',
+        encoding="utf-8",
+    )
+    (assets / "index-DEF456.css").write_text("body{}", encoding="utf-8")
+    (assets / "duckdb-browser-mvp.worker-HASH.js").write_text("//worker", encoding="utf-8")
+    (assets / "duckdb-mvp-HASH.wasm").write_bytes(b"\x00wasm-bytes" * 100)
+    (dist / "pp_build_meta.json").write_text(
+        json.dumps({"duckdbWasmVersion": "9.9.9"}), encoding="utf-8"
+    )
+    return dist
+
+
+@pytest.fixture
+def patched(monkeypatch, fake_dist):
+    monkeypatch.setattr(viewer_pages, "find_viewer_dist", lambda: fake_dist)
+    monkeypatch.setattr(viewer_pages, "_discover_installed_extensions", lambda: [])
+    return fake_dist
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+class TestReadDuckdbWasmVersion:
+    def test_reads_from_meta(self, fake_dist):
+        assert _read_duckdb_wasm_version(fake_dist) == "9.9.9"
+
+    def test_falls_back_when_missing(self, tmp_path):
+        assert _read_duckdb_wasm_version(tmp_path) == _DEFAULT_DUCKDB_WASM_VERSION
+
+    def test_falls_back_on_malformed_meta(self, tmp_path):
+        (tmp_path / "pp_build_meta.json").write_text("not json", encoding="utf-8")
+        assert _read_duckdb_wasm_version(tmp_path) == _DEFAULT_DUCKDB_WASM_VERSION
+
+
+class TestDuckdbCdnUrls:
+    def test_pins_version_and_uses_mvp_files(self, fake_dist):
+        worker, wasm = _duckdb_cdn_urls(fake_dist)
+        assert "@duckdb/duckdb-wasm@9.9.9/" in worker
+        assert worker.endswith("/duckdb-browser-mvp.worker.js")
+        assert wasm.endswith("/duckdb-mvp.wasm")
+
+
+class TestRewriteLocalRefsToCdn:
+    def test_rewrites_relative_paths(self):
+        out = _rewrite_local_refs_to_cdn(INDEX_HTML, VIEWER_CDN_BASE)
+        base = VIEWER_CDN_BASE.rstrip("/") + "/"
+        assert f'{base}assets/index-ABC123.js' in out
+        assert f'{base}icon.png' in out
+        assert f'{base}logo.png' in out
+
+    def test_leaves_external_and_anchor_refs_untouched(self):
+        out = _rewrite_local_refs_to_cdn(INDEX_HTML, VIEWER_CDN_BASE)
+        assert 'href="https://cdn.jsdelivr.net/npm/bootstrap' in out
+        assert 'href="https://example.com/page"' in out
+        assert 'href="#anchor"' in out
+
+
+# ---------------------------------------------------------------------------
+# build_single_file_viewer_html
+# ---------------------------------------------------------------------------
+
+class TestLightBuild:
+    """Default: inline the app bundle but load DuckDB WASM from a CDN."""
+
+    def test_inlines_app_js(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html")  # light is default
+        html = out.read_text(encoding="utf-8")
+        assert "console.log('app');" in html
+
+    def test_injects_duckdb_cdn_globals(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html")
+        html = out.read_text(encoding="utf-8")
+        assert "window.__PP_DUCKDB_WORKER_URL =" in html
+        assert "@duckdb/duckdb-wasm@9.9.9/" in html
+
+    def test_does_not_inline_duckdb_wasm(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html")
+        html = out.read_text(encoding="utf-8")
+        # The wasm bytes must not be embedded; the runtime ref is left untouched.
+        assert "data:application/wasm" not in html
+        assert "duckdb-mvp-HASH.wasm" in html  # original ref still present, not a data URL
+        assert "wasm-bytes" not in html
+
+    def test_no_github_pages_refs(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html")
+        assert "ida-mdc.github.io" not in out.read_text(encoding="utf-8")
+
+    def test_keeps_bootstrap_cdn_link(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html")
+        html = out.read_text(encoding="utf-8")
+        assert "cdn.jsdelivr.net/npm/bootstrap" in html
+
+
+class TestBaseUrlBuild:
+    """--base-url: reference the app bundle from a host instead of inlining."""
+
+    def test_references_app_bundle_from_base_url(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html", base_url=VIEWER_CDN_BASE)
+        html = out.read_text(encoding="utf-8")
+        assert f"{VIEWER_CDN_BASE.rstrip('/')}/assets/index-ABC123.js" in html
+        assert "console.log('app');" not in html  # not inlined
+
+    def test_still_uses_duckdb_cdn(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html", base_url="https://h/v/")
+        html = out.read_text(encoding="utf-8")
+        assert "window.__PP_DUCKDB_WORKER_URL =" in html
+
+    def test_offline_takes_precedence_over_base_url(self, patched, tmp_path):
+        out = build_single_file_viewer_html(
+            tmp_path / "v.html", offline=True, base_url=VIEWER_CDN_BASE
+        )
+        html = out.read_text(encoding="utf-8")
+        assert "ida-mdc.github.io" not in html
+        assert "console.log('app');" in html  # inlined, not referenced
+
+
+class TestOfflineBuild:
+    def test_inlines_local_js(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html", offline=True)
+        html = out.read_text(encoding="utf-8")
+        assert "console.log('app');" in html
+
+    def test_no_cdn_app_bundle_or_duckdb_globals(self, patched, tmp_path):
+        out = build_single_file_viewer_html(tmp_path / "v.html", offline=True)
+        html = out.read_text(encoding="utf-8")
+        assert "ida-mdc.github.io" not in html
+        assert "window.__PP_DUCKDB_WORKER_URL =" not in html
+
+    def test_both_modes_inject_extension_urls(self, patched, tmp_path):
+        light = build_single_file_viewer_html(tmp_path / "l.html").read_text("utf-8")
+        offline = build_single_file_viewer_html(tmp_path / "o.html", offline=True).read_text("utf-8")
+        assert "window.__PP_EXTENSION_URLS =" in light
+        assert "window.__PP_EXTENSION_URLS =" in offline

--- a/viewer/src/loader.js
+++ b/viewer/src/loader.js
@@ -29,10 +29,20 @@ export async function terminateDuckDB(db, conn) {
   try { await db?.terminate(); } catch {}
 }
 
-/** Initialise DuckDB WASM using locally bundled files (avoids CDN version mismatches). */
+/**
+ * Initialise DuckDB WASM.
+ *
+ * By default the locally bundled files are used (avoids CDN version mismatches).
+ * A static "light" HTML build references the app bundle from a remote host, so
+ * the bundled relative paths would resolve against the local file:// page and
+ * break. Such builds set window.__PP_DUCKDB_WORKER_URL / __PP_DUCKDB_WASM_URL to
+ * absolute CDN URLs which take precedence when present.
+ */
 export async function initDuckDB() {
-  const absWorkerUrl = new URL(duckdbMvpWorkerUrl, location.href).href;
-  const absWasmUrl   = new URL(duckdbMvpWasmUrl,   location.href).href;
+  const absWorkerUrl = window.__PP_DUCKDB_WORKER_URL
+    || new URL(duckdbMvpWorkerUrl, location.href).href;
+  const absWasmUrl   = window.__PP_DUCKDB_WASM_URL
+    || new URL(duckdbMvpWasmUrl,   location.href).href;
 
   const workerUrl = URL.createObjectURL(
     new Blob([`importScripts("${absWorkerUrl}");`], { type: 'text/javascript' }),

--- a/viewer/vite.config.js
+++ b/viewer/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import { cpSync, rmSync, readFileSync, existsSync } from 'fs';
+import { cpSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 
 // After a production build, sync the output into the Python package so that
@@ -63,6 +63,29 @@ function emitJsLicenses() {
   };
 }
 
+// Record the DuckDB WASM version into the build output so the Python
+// `build-viewer-html --no-offline` builder can point the worker/wasm at the
+// matching jsdelivr CDN release instead of inlining the ~38 MB local files.
+function writeBuildMeta() {
+  return {
+    name: 'write-build-meta',
+    writeBundle() {
+      try {
+        const duckdbPkg = JSON.parse(readFileSync(
+          resolve(__dirname, 'node_modules/@duckdb/duckdb-wasm/package.json'),
+          'utf8',
+        ));
+        writeFileSync(
+          resolve(__dirname, 'dist/pp_build_meta.json'),
+          JSON.stringify({ duckdbWasmVersion: duckdbPkg.version }, null, 2) + '\n',
+        );
+      } catch (e) {
+        console.warn(`\n⚠ pp_build_meta.json write failed: ${e.message}`);
+      }
+    },
+  };
+}
+
 function syncToPythonPackage() {
   return {
     name: 'sync-viewer-dist',
@@ -104,7 +127,7 @@ export default defineConfig({
     exclude: ['@duckdb/duckdb-wasm'],
   },
 
-  plugins: [stripMissingSourcemaps(), emitJsLicenses(), syncToPythonPackage()],
+  plugins: [stripMissingSourcemaps(), emitJsLicenses(), writeBuildMeta(), syncToPythonPackage()],
 
   build: {
     target: 'es2022',


### PR DESCRIPTION
Adds the offline/light/base-url modes for the single-file HTML viewer

closes #149 