### PR TITLE
loader-bioio: add bioformats for support of .ims files

### DIFF
--- a/packages/pixel-patrol-loader-bio/pyproject.toml
+++ b/packages/pixel-patrol-loader-bio/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pixel-patrol-base==0.8.0",
     "zarr==3.1.1",
     "tifffile==2025.9.9",
+    "bioio-bioformats==2.0.0",
 ]
 
 [project.urls]

--- a/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/bioio_loader.py
+++ b/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/bioio_loader.py
@@ -12,6 +12,7 @@ import polars as pl
 import tifffile
 from bioio import BioImage
 from bioio_base.exceptions import UnsupportedFileFormatError
+import bioio_bioformats
 
 from pixel_patrol_base.core.contracts import FileInfo
 from pixel_patrol_base.core.loader_schema import (
@@ -95,21 +96,42 @@ def _load_bioio_image(file_path: Path) -> Optional[BioImage]:
     """
     Try BioImage, then fall back to imageio reader; return None if both fail.
     """
-    try:
-        file_path = Path(file_path)
-        if file_path.suffix.lower() in _TIFF_EXTENSIONS:
+    file_path = Path(file_path)
+
+    def _try_bioio_tif_reader():
+        if file_path.suffix.lower() not in _TIFF_EXTENSIONS:
+            return None
+        try:
             reader = bioio_ome_tiff.Reader if _is_ome_tiff(file_path) else bioio_tifffile.Reader
             return BioImage(file_path, reader=reader)
-        return BioImage(file_path)
-    except UnsupportedFileFormatError:
+        except UnsupportedFileFormatError:
+            return None
+
+    def _try_imageio_reader():
         try:
             return BioImage(file_path, reader=bioio_imageio.Reader)
         except Exception as e:
-            logger.warning(f"Could not load '{file_path}' with BioImage (imageio fallback): {e}")
             return None
+
+    def _try_bioformats_reader():
+        img = BioImage(file_path, reader=bioio_bioformats.Reader)
+        img.data  # force load to confirm the file is actually readable
+        return img
+
+    try:
+        img = _try_bioio_tif_reader()
+        if img is not None:
+            return img
+        img = _try_imageio_reader()
+        if img is not None:
+            return img
+        img = _try_bioformats_reader()
+        if img is not None:
+            return img
     except Exception as e:
         logger.warning(f"Could not load '{file_path}' with BioImage: {e}")
         return None
+
 
 class BioIoLoader:
     """
@@ -120,7 +142,7 @@ class BioIoLoader:
     NAME = "bioio"
     DESCRIPTION = "Opens a wide range of microscopy and standard image formats via BioIO, extracting pixel data and image metadata (dimensions, channels, pixel sizes)."
 
-    SUPPORTED_EXTENSIONS: Set[str] = {"czi", "tif", "tiff", "ome.tif", "nd2", "lif", "jpg", "jpeg", "png", "bmp", "ome.zarr", "zarr"}
+    SUPPORTED_EXTENSIONS: Set[str] = {"czi", "tif", "tiff", "ome.tif", "nd2", "lif", "jpg", "jpeg", "png", "bmp", "ome.zarr", "zarr", "ims"}
 
     OUTPUT_SCHEMA: Dict[str, Any] = dict(RASTER_IMAGE_LOADER_SCHEMA)
     OUTPUT_SCHEMA_PATTERNS: List[tuple[str, Any]] = list(RASTER_IMAGE_LOADER_SCHEMA_PATTERNS)


### PR DESCRIPTION
what is missing: test for loading the different file types and checking that everything actually works.
if the reason why [bioio.BioImage.determine_plugin()](https://bioio-devs.github.io/bioio/bioio.html#bioio.BioImage.determine_plugin) was not used becomes clear again, it should be documented.

One issue of bioformats is that on first use a java environment is downloaded and used. This also leads to a lot of log messages. 