### PR TITLE
WIP: viewer: Open-in-napari action

### DIFF
--- a/packages/pixel-patrol-base/src/pixel_patrol_base/napari_launcher.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/napari_launcher.py
@@ -1,0 +1,110 @@
+"""Open one image - or the exact slice / tile / chunk a viewer row represents - in napari.
+
+Run as a subprocess by the viewer server's ``/api/open-napari`` endpoint so napari's
+Qt event loop stays isolated from the HTTP server thread.  It reuses the very loader
+the processing pipeline used, takes its lazy Dask array, and indexes the same block
+the clicked row was measured on - so what you see in napari is exactly what Pixel
+Patrol reported for that row.
+
+    python -m pixel_patrol_base.napari_launcher \
+        --path /data/img.ome.tif --loader tifffile \
+        --slices '{"Z": [3, 4]}' --child-id 0 --name img.ome.tif
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from pixel_patrol_base.core.record import Record
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_loader(loader_name: Optional[str], file_path: Path):
+    """Return the loader instance to use: the recorded one, else one that claims the extension."""
+    from pixel_patrol_base.plugin_registry import discover_loader, discover_plugins_from_entrypoints
+
+    if loader_name:
+        return discover_loader(loader_id=loader_name)
+
+    ext = file_path.name.lower().split(".", 1)[-1]
+    for loader_cls in discover_plugins_from_entrypoints("pixel_patrol.loader_plugins"):
+        supported = {e.lower() for e in getattr(loader_cls, "SUPPORTED_EXTENSIONS", set()) or set()}
+        if ext in supported or file_path.suffix.lstrip(".").lower() in supported:
+            return loader_cls()
+    raise RuntimeError(f"No loader records for '{file_path.name}' and none claims its extension.")
+
+
+def _load_record(loader, file_path: Path, child_id: Optional[str]) -> Record:
+    """Load the whole-file Record, or a single sub-image for container formats."""
+    if child_id in (None, ""):
+        return loader.load(file_path)
+    index = int(child_id)
+    for _sub_id, record in loader.load_range(file_path, index, index + 1):
+        return record
+    raise ValueError(f"Sub-image {child_id} not found in {file_path}")
+
+
+def _slice_tuple(dim_order: str, axis_slices: Dict[str, List[int]], shape: Tuple[int, ...]) -> Tuple[slice, ...]:
+    """Build one slice per axis: the row's [start, stop) where pinned, whole axis otherwise.
+
+    ``axis_slices`` is keyed by upper-case axis letter; stops are clamped to the loaded
+    array's real extent so a stale row can never index out of bounds.
+    """
+    out: List[slice] = []
+    for i, axis in enumerate(dim_order):
+        span = axis_slices.get(axis.upper())
+        if span is None:
+            out.append(slice(None))
+            continue
+        start = max(0, min(int(span[0]), shape[i] - 1))
+        stop = max(start + 1, min(int(span[1]), shape[i]))
+        out.append(slice(start, stop))
+    return tuple(out)
+
+
+def open_in_napari(
+    file_path: Path,
+    loader_name: Optional[str],
+    axis_slices: Dict[str, List[int]],
+    child_id: Optional[str] = None,
+    name: Optional[str] = None,
+) -> None:
+    """Load the block the row describes and hand it (lazily) to napari."""
+    import napari
+
+    loader = _resolve_loader(loader_name, file_path)
+    record = _load_record(loader, file_path, child_id)
+    block = record.data[_slice_tuple(record.dim_order, axis_slices, tuple(record.data.shape))]
+
+    viewer = napari.Viewer()
+    viewer.add_image(block, name=name or file_path.name)
+    if len(record.dim_order) == block.ndim:
+        viewer.dims.axis_labels = tuple(record.dim_order)
+    napari.run()
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Open an image (or one of its slices) in napari.")
+    parser.add_argument("--path", required=True)
+    parser.add_argument("--loader", default="")
+    parser.add_argument("--slices", default="{}", help="JSON: axis letter -> [start, stop]")
+    parser.add_argument("--child-id", default=None)
+    parser.add_argument("--name", default=None)
+    args = parser.parse_args(argv)
+
+    open_in_napari(
+        file_path=Path(args.path),
+        loader_name=args.loader or None,
+        axis_slices=json.loads(args.slices),
+        child_id=args.child_id,
+        name=args.name,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_server.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer_server.py
@@ -18,8 +18,11 @@ also be used.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import socket
+import subprocess
+import sys
 import threading
 import warnings
 import webbrowser
@@ -216,6 +219,8 @@ class _ViewerHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         if self.path == "/api/query":
             self._serve_query()
+        elif self.path == "/api/open-napari":
+            self._serve_open_napari()
         else:
             self.send_error(404)
 
@@ -258,6 +263,72 @@ class _ViewerHandler(BaseHTTPRequestHandler):
         except Exception as exc:
             self._send_error_text(400, str(exc))
 
+
+    # ------------------------------------------------------------------
+    # /api/open-napari  - open the source image (slice/tile/chunk) in napari
+    # ------------------------------------------------------------------
+
+    def _serve_open_napari(self) -> None:
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            body   = json.loads(self.rfile.read(length))
+            frn    = int(body["file_row_number"])
+        except Exception as exc:
+            self._send_error_text(400, f"Bad request: {exc}")
+            return
+
+        if importlib.util.find_spec("napari") is None:
+            self._send_error_text(501, "napari is not installed in the viewer's Python environment.")
+            return
+
+        base_dir = self.parquet_meta.get("pp_base_dir")
+        if not base_dir:
+            self._send_error_text(
+                409, "This parquet has no recorded base directory, so source images can't be located."
+            )
+            return
+
+        row = self._fetch_row(frn)
+        if row is None:
+            self._send_error_text(404, f"No row with file_row_number={frn}.")
+            return
+
+        source_path = (Path(base_dir) / row["path"]).resolve()
+        if not source_path.exists():
+            self._send_error_text(404, f"Source image not found: {source_path}")
+            return
+
+        cmd = [
+            sys.executable, "-m", "pixel_patrol_base.napari_launcher",
+            "--path",   str(source_path),
+            "--loader", self.parquet_meta.get("pp_loader") or "",
+            "--slices", json.dumps(_axis_slices_for_row(row)),
+            "--name",   str(row.get("name") or source_path.name),
+        ]
+        child_id = row.get("child_id")
+        if child_id not in (None, ""):
+            cmd += ["--child-id", str(child_id)]
+
+        try:
+            subprocess.Popen(cmd)  # detached; its Qt loop must not block the server
+        except Exception as exc:
+            self._send_error_text(500, f"Failed to launch napari: {exc}")
+            return
+
+        payload = json.dumps({"ok": True, "path": str(source_path)}).encode()
+        self.send_response(200)
+        self._common_headers("application/json", len(payload))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _fetch_row(self, file_row_number: int) -> Optional[dict]:
+        """Return the full obs row for a file_row_number as a plain dict, or None."""
+        with self.query_lock:
+            table = self.duck_conn.execute(
+                f"SELECT * FROM pp_all WHERE file_row_number = {file_row_number} LIMIT 1"
+            ).fetch_arrow_table()
+        rows = table.to_pylist()
+        return rows[0] if rows else None
 
     # ------------------------------------------------------------------
     # /api/export-parquet  - filtered parquet download with metadata
@@ -593,6 +664,24 @@ def serve_viewer(
 # ---------------------------------------------------------------------------
 # Utilities
 # ---------------------------------------------------------------------------
+
+def _axis_slices_for_row(row: dict) -> dict:
+    """Map a row's obs coordinates to {AXIS: [start, stop]} for the axes it pins.
+
+    An axis is pinned when its ``dim_<a>`` origin is non-null; the row then covers
+    ``[origin, origin + size_<A>)`` along it. Axes left null span their full extent
+    and are omitted, so a whole-image row yields ``{}`` (open the whole image).
+    """
+    dim_order = row.get("dim_order") or ""
+    slices: dict = {}
+    for axis in dim_order:
+        origin = row.get(f"dim_{axis.lower()}")
+        if origin is None:
+            continue
+        extent = row.get(f"size_{axis.upper()}") or 1
+        slices[axis.upper()] = [int(origin), int(origin) + int(extent)]
+    return slices
+
 
 def _parse_range(header: str, total: int) -> tuple[int, int]:
     """Parse ``Range: bytes=start-end`` and clamp to file size."""

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -4,6 +4,7 @@ import { SERVER_MODE, makeServerConn } from './query.js';
 import { initControls, initStaticUi } from './controls.js';
 import { renderAll } from './renderer.js';
 import { registry } from './plugin-registry.js';
+import { napariInspector } from './napari.js';
 import { state, on } from './state.js';
 import { buildWhere } from './sql.js';
 import { buildScopedWhere } from './cohort-sql.js';
@@ -86,6 +87,16 @@ async function boot() {
   on('query',  doRender);
   on('render', doRender);
   registry.onAdd(doRender);
+
+  // Public hook for extensions to contribute point-inspector sections / widgets,
+  // mirroring how they already register via extension.json plugin modules.
+  window.PixelPatrol = {
+    registerInspector: (c) => registry.registerInspector(c),
+    registerPlugin:    (p) => registry.register(p),
+  };
+  // Built-in contributor: "Open in napari" (self-gates to server mode).
+  registry.registerInspector(napariInspector);
+
   initStaticUi();
 
   // ── Server mode: native DuckDB via local Python server ──────────────────────

--- a/viewer/src/napari.js
+++ b/viewer/src/napari.js
@@ -1,0 +1,72 @@
+/**
+ * napari point-inspector contributor.
+ *
+ * Registered into the point-inspector drawer (see registry.registerInspector).
+ * Only available when the viewer is served from Python (window.__PP_SERVER),
+ * where the backend can service /api/open-napari - which reuses the pipeline's
+ * loader to open the exact slice/tile/chunk the clicked row represents.
+ *
+ * This is the reference "hook something into the point detail" plugin: an
+ * external viewer extension could register an equivalent contributor via
+ * window.PixelPatrol.registerInspector(...).
+ */
+
+import { SERVER_MODE } from './query.js';
+
+/** True when the backend can service /api/open-napari (Python-launched viewer). */
+export const NAPARI_ENABLED = SERVER_MODE;
+
+let toastEl = null;
+
+/** Show a brief, self-dismissing status message in the corner. */
+function toast(message, isError = false) {
+  if (!toastEl) {
+    toastEl = document.createElement('div');
+    toastEl.style.cssText =
+      'position:fixed;bottom:20px;right:20px;z-index:9999;max-width:340px;' +
+      'padding:10px 14px;border-radius:6px;font-size:13px;color:#fff;' +
+      'box-shadow:0 2px 8px rgba(0,0,0,0.25);transition:opacity 0.3s;';
+    document.body.appendChild(toastEl);
+  }
+  toastEl.style.background = isError ? '#b23b3b' : '#2f7d4f';
+  toastEl.textContent = message;
+  toastEl.style.opacity = '1';
+  clearTimeout(toast._timer);
+  toast._timer = setTimeout(() => { toastEl.style.opacity = '0'; }, isError ? 6000 : 3500);
+}
+
+/** Ask the server to open the given row's image (or slice) in napari. */
+async function openInNapari(fileRowNumber) {
+  toast('Opening in napari…');
+  try {
+    const res = await fetch('/api/open-napari', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file_row_number: fileRowNumber }),
+    });
+    if (!res.ok) {
+      toast(`napari: ${(await res.text()) || res.statusText}`, true);
+      return;
+    }
+    toast('napari window opening…');
+  } catch (err) {
+    toast(`napari: ${err.message}`, true);
+  }
+}
+
+/** The point-inspector contributor object. */
+export const napariInspector = {
+  id: 'napari',
+  label: 'napari',
+  order: 20,  // below the data table (thumbnail uses a negative order to sit on top)
+  requires: (row) => NAPARI_ENABLED && row.file_row_number != null && row.type !== 'folder',
+  render(container, row) {
+    const btn = document.createElement('button');
+    btn.textContent = 'Open in napari';
+    btn.style.cssText =
+      'padding:6px 12px;border:1px solid rgba(128,128,128,0.4);border-radius:6px;' +
+      'cursor:pointer;background:var(--card-bg,#fff);color:inherit;font-size:13px;';
+    btn.addEventListener('click', () => openInNapari(Number(row.file_row_number)));
+    container.appendChild(btn);
+  },
+};


### PR DESCRIPTION
Adds a local napari launcher and viewer server, and registers an 'Open in napari' inspector contributor (server mode) exposed through the window.PixelPatrol hook.

Would only work if the file path can be resolved.

This is not used in the UI somewhere and needs further considerations, just putting it here because I tried it and it's doing something useful.