### PR TITLE
Hide across-dims widgets when parquet has no dim slices

### DIFF
--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_stats_across_dims.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_stats_across_dims.js
@@ -231,7 +231,6 @@ async function acrossDimsCondensedSummary(ctx) {
 // metric, along the first non-spatial dimension that has data. Mirrors the
 // non-spatial query path in renderAcrossDims, kept minimal for the tile preview.
 async function acrossDimsCondensedPlot(ctx, container, filterMetric, metricPref) {
-  if (!ctx.schema.isLongFormat) return false;
   const { q, groupCol: gcFn } = ctx.sql;
   const metrics = (ctx.schema.metricCols ?? []).filter(filterMetric);
   const metric  = metricPref.find(m => metrics.includes(m)) ?? metrics[0];

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_stats_across_dims.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_stats_across_dims.js
@@ -295,7 +295,7 @@ function makeAcrossDimsPlugin(id, label, info, filterMetric, condensedMessage, m
     id, label, info, shortLabel, group: 'Dataset Stats', scope: 'slice', multiPlot: true,
     inputs: inputMetrics ? [...inputMetrics] : [],
     requires(schema) {
-      return schema.metricCols.some(filterMetric);
+      return !!schema.hasDimSlices && schema.metricCols.some(filterMetric);
     },
     ...(condensedMessage ? { condensedMessage } : {}),
     async condensedPlot(container, ctx) {

--- a/packages/pixel-patrol-base/tests/viewer/widgets.test.js
+++ b/packages/pixel-patrol-base/tests/viewer/widgets.test.js
@@ -90,8 +90,8 @@ const ENABLING_SCHEMA = {
   'metadata':                  { allCols: ['dtype'] },
   'violin-basic':              { metricCols: ['mean_intensity'] },
   'violin-quality':            { metricCols: ['laplacian_variance'] },
-  'stats-across-dims-basic':   { metricCols: ['mean_intensity'] },
-  'stats-across-dims-quality': { metricCols: ['laplacian_variance'] },
+  'stats-across-dims-basic':   { metricCols: ['mean_intensity'], hasDimSlices: true },
+  'stats-across-dims-quality': { metricCols: ['laplacian_variance'], hasDimSlices: true },
 };
 
 describe('widget requires()', () => {

--- a/viewer/src/loader.js
+++ b/viewer/src/loader.js
@@ -149,6 +149,9 @@ export async function finishLoad(conn, parquetPath = null) {
   const schema = detectSchema(columns);
   schema.rowIdColumn = pickRowIdColumnFromSchema(schema.allCols);
 
+  const sliceCheck = await conn.query(`SELECT (MAX(obs_level) > 0) AS v FROM pp_all`);
+  schema.hasDimSlices = !!sliceCheck.toArray()[0].v;
+
   // Populate dimensionInfo by querying distinct values from pp_all.
   if (schema.dimCols.length > 0) {
     for (const dimCol of schema.dimCols) {


### PR DESCRIPTION
## Summary
- Set `schema.hasDimSlices` at load time by checking if any `obs_level > 0` rows exist
- Gate across-dims `requires()` on `hasDimSlices` so widgets don't appear for 2D-only parquets (or multidim images processed without slicing)
- Remove stale `isLongFormat` guard in `acrossDimsCondensedPlot` (missed in #203) that was silently breaking tile plots
