### PR TITLE
Add plot info toggle and per-metric side notes

### DIFF
--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_custom_plot.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_custom_plot.js
@@ -511,18 +511,15 @@ export default {
   shortLabel: 'Explore',
   group: 'Explore',
   info:  'Build your own plot from the columns in your current data.\n\n' +
-         'Each plot has its own **Slice by** toggles (top right) and a **per image** / ' +
-         '**per slice** badge showing what one of its datapoints represents. With nothing ' +
-         'toggled, each point is one whole-image aggregate (**per image**). Switching a ' +
-         'toggle on stops that dimension from being aggregated away, so each point becomes ' +
-         'one (image × that dimension) combination instead (**per slice**) - e.g. switching ' +
-         'on "C" gives one point per C-slice per image.\n\n' +
+         'Each plot has its own **Slice by** toggles and **per image** / **per slice** badge, ' +
+         'controlling whether each datapoint is a whole-image aggregate (**per image**) or one ' +
+         '(image × dimension) combination (**per slice**).\n\n' +
          '- **Two numerics** → scatter\n' +
          '- **Categorical × numeric** → violin or bar (mean ± sd)\n' +
          '- **Any column × (count)** → count bar\n' +
          '- **Two categoricals** → count heatmap\n\n' +
-         'Single unique value → table instead of plot. For scatter, this applies when the Y ' +
-         'column is constant across all rows (regardless of X).\n\n' +
+         'If a column has **no variance**, it is shown in a table instead of a plot. For scatter, ' +
+         'this checks the Y column only (regardless of X).\n\n' +
          '**Color by:**\n' +
          '- **(none)** → a single, ungrouped trace (no legend), in a color you pick with the swatch ' +
          'next to "Color by".\n' +
@@ -540,11 +537,11 @@ export default {
          '**Heatmaps** (two categoricals) never use color-by/hue grouping — instead, pick a single ' +
          'base color with the swatch; cell counts are shown on a white-to-color scale (white = 0, ' +
          'your color = the maximum). Check **Invert** to reverse this (your color = 0, white = the maximum).\n\n' +
-         '**Dates**: `modification_date` is always plotted as a date axis (never as a category), ' +
-         'shown as a readable timestamp. "Bar (mean ± sd)" is unavailable for it — use violin instead.\n\n' +
          `**Missing values**: for violin/bar/heatmap, rows where a *categorical* axis is null are ` +
          `grouped into their own "${NULL_LABEL}" category (shown last). For scatter, rows where X or Y ` +
          `is null can't be placed on a numeric axis and are excluded — a warning shows how many.\n\n` +
+         '**↓ Export plugin** downloads the plot as a standalone `plugin_*.js` file - ' +
+         'drop it into your own viewer extension folder to keep this exact plot as a permanent widget.\n\n' +
          '**＋ Add plot** adds an independent plot below.',
 
   requires(schema) {

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_dim_size.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_dim_size.js
@@ -12,13 +12,13 @@ export default {
   multiPlot: true,
   label: 'Dimensionality',
   info: [
-    'Shows how **image dimensions** (X, Y, Z, T, …) vary across the dataset.',
+    'Shows how **image dimension sizes** (e.g. X, Y, Z, T, …) vary across the dataset.',
     '',
     'Includes an X/Y size scatter plot and per-dimension strip plots.',
     '',
-    '**Use this to identify**',
-    '- unexpected dimension sizes',
-    '- mismatched shapes between groupings',
+    'If a dimension has **no variance**, it is summarized in a table instead of a plot.',
+    '',
+    'Use this to identify **unexpected dimension sizes** and **mismatched shapes** within/between groupings.',
   ].join('\n'),
 
   requires(schema) {

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_dim_size.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_dim_size.js
@@ -1,6 +1,9 @@
 const MAX_XY_BUBBLE = 50_000;  // above this many files, switch the X/Y scatter to a heatmap
 const HEATMAP_BINS  = 70;      // target bin count per axis for the X/Y heatmap
 
+// Matches size_X/size_Y/size_Z/... (one axis letter) - not e.g. size_bytes.
+const SIZE_DIM_RE = /^size_[A-Za-z]$/;
+
 export default {
   id: 'dim-size',
   inputs: ['size_*'],
@@ -19,13 +22,13 @@ export default {
   ].join('\n'),
 
   requires(schema) {
-    return schema.allCols.some(c => c.startsWith('size_') && !c.startsWith('__'));
+    return schema.allCols.some(c => SIZE_DIM_RE.test(c));
   },
 
   async overviewMessage(ctx) {
     try {
       const { q, andWhere } = ctx.sql;
-      const sizeCols = ctx.schema.allCols.filter(c => c.startsWith('size_') && !c.startsWith('__'));
+      const sizeCols = ctx.schema.allCols.filter(c => SIZE_DIM_RE.test(c));
       const hasXY    = sizeCols.includes('size_X') && sizeCols.includes('size_Y');
       const KNOWN_DIMS = { size_Z: 'Z slices', size_T: 'timepoints', size_C: 'channels', size_S: 'series/tiles' };
       const extraDimCols = sizeCols.filter(c => c !== 'size_X' && c !== 'size_Y' && c !== 'num_pixels');
@@ -67,7 +70,7 @@ export default {
 
   async overviewPlot(container, ctx) {
     const { andWhere, sample, groupCol: gcFn } = ctx.sql;
-    const sizeCols = ctx.schema.allCols.filter(c => c.startsWith('size_') && !c.startsWith('__'));
+    const sizeCols = ctx.schema.allCols.filter(c => SIZE_DIM_RE.test(c));
     if (!(sizeCols.includes('size_X') && sizeCols.includes('size_Y'))) return false;
 
     const rows = await ctx.queryRows(`
@@ -93,7 +96,7 @@ export default {
 
   async render(container, ctx) {
     try {
-      const sizeCols = ctx.schema.allCols.filter(c => c.startsWith('size_') && !c.startsWith('__'));
+      const sizeCols = ctx.schema.allCols.filter(c => SIZE_DIM_RE.test(c));
       await renderSizeAvailability(container, ctx, sizeCols);
       await renderXYDistribution(container, ctx, sizeCols);
       await renderDimDistributions(container, ctx, sizeCols);

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_file_stats.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_file_stats.js
@@ -18,12 +18,6 @@ export default {
   info: [
     'High-level **file statistics** for the dataset.',
     '',
-    '**Charts**',
-    '- File count by extension',
-    '- Total size by extension',
-    '- File count by size bin',
-    '- File modification timeline',
-    '',
     'If a property has **no variance** (e.g. all files share the same extension), it is summarized in the table instead of a chart.',
   ].join('\n'),
   label: 'File Statistics',

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_metadata.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_metadata.js
@@ -5,11 +5,6 @@ const META_COLS = [
 
 const DIST_COLS = ['dtype', 'dim_order'];
 
-const DTYPE_INCONSISTENCY_NOTE =
-  ' Mixed <code>dtype</code> is worth a particularly close look: a pixel value of 100 sits near the ' +
-  'bottom of the <code>uint16</code> range but the middle of the <code>uint8</code> range, so the ' +
-  'same number can mean very different things.';
-
 // Distinct categories of `col` plus a (cat, group) → count lookup. Shared by the
 // overview tile preview and the full distribution bars so both render from one
 // query instead of each rebuilding the per-group counts.
@@ -56,12 +51,10 @@ function prependInconsistencyWarning(container, ctx, varied) {
   const { escapeHtml, humanList } = ctx.plot;
   const list = humanList(varied.map(({ col, cats }) =>
     `<code>${col}</code> (${cats.map(c => `<code>${escapeHtml(c)}</code>`).join(', ')})`));
-  const dtypeNote = varied.some(v => v.col === 'dtype') ? DTYPE_INCONSISTENCY_NOTE : '';
   ctx.plot.prependWarning(container, {
     level: 'red',
     html: `This report contains more than one value for ${list}. ` +
-      `That can point to inconsistent acquisition - different instruments, software, or settings - ` +
-      `and is worth checking before comparing groups.${dtypeNote}`,
+      `That can point to inconsistent acquisition - different instruments, software, or settings.`,
   });
 }
 
@@ -83,7 +76,7 @@ export default {
   multiPlot: true,
   label: 'Metadata',
   shortLabel: 'Image Metadata',
-  info: 'Shows the distribution of **pixel data types** and **dimension ordering** across groupings.\n\nAlso lists properties shared by all files, and available dimension ranges.',
+  info: 'Shows the distribution of **pixel data types** and **dimension ordering** across groupings.\n\nIf a property has **no variance** (e.g. every file has the same pixel dtype), it is summarized in a table instead of a chart.',
 
   requires(schema) {
     const hasDist = DIST_COLS.some(c => schema.allCols.includes(c));

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_mosaic.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_mosaic.js
@@ -24,8 +24,8 @@ export default {
   info: [
     'Displays a **thumbnail mosaic**, one thumbnail per file.',
     '',
-    '- Thumbnails are generated from the central slice in all non-XY dimensions.',
-    '- Sorting by a measurement (e.g. mean, min, max) can reveal visual trends.',
+    '- Thumbnails are generated from the central slice in all non-XY, non-RGB dimensions.',
+    '- Sorting by a numeric column can reveal visual trends.',
     '- Border colors indicate the group of each image.',
     '- **Hover** over an image to see its filename.',
   ].join('\n'),

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_stats_across_dims.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_stats_across_dims.js
@@ -8,24 +8,20 @@ const QUALITY_METRIC_BASES = new Set(Object.keys(QUALITY_METRIC_INFO));
 const COL_BG    = ['#ffffff', '#f4f6f9'];
 const MIN_COL_PX = 180;  // min width per "Across 'X' slices" column in the grid
 
-const RAGGED_INFO = 'The dashed line (right-hand axis) shows the **% of images that still have a ' +
+const RAGGED_INFO = 'The dashed line shows the **% of images that still have a ' +
   'slice at this position**, per condition - useful for spotting datasets where images have ' +
   'different numbers of slices.';
 
 const BASIC_INFO = [
   'Shows how image statistics (e.g., mean, std, min, max) change **across different dimension slices**.',
-  '', 'Useful for identifying drift, artifacts, or unexpected variation within (e.g.) T/C/Z/S dimensions.',
-  '', 'You can select slices in the dropdowns to filter the tables.',
+  '', 'Useful for identifying drift, artifacts, or unexpected variation.',
   '', RAGGED_INFO,
 ].join('\n');
 
 const QUALITY_INFO = [
-  'Shows how **image quality metrics** change across (e.g. T, C, Z, S) slices.',
-  '', 'Use this view to detect:',
-  '- drift in focus or noise over time (T)',
-  '- channel-specific artifacts (C)',
-  '- depth-dependent quality changes (Z)',
-  '', RAGGED_INFO,
+  'Shows how **image quality metrics** change across different dimension slices.',
+  '', 'Useful to detect e.g. drift in focus or noise over time (T) and depth (Z) as well as channel (C) specific artifacts.',
+  '', 'The dashed line shows the **% of images that still have a slice at this position**, per condition.',
 ].join('\n');
 
 // X and Y are spatial tile coordinates. When querying non-spatial dims we
@@ -136,7 +132,7 @@ function appendRetentionLegend(container, ctx) {
   const dash = document.createElement('span');
   dash.style.cssText = 'display:flex;align-items:center;gap:5px;color:#6c757d';
   dash.innerHTML = '<span style="display:inline-block;width:16px;height:0;border-top:1px dashed #6c757d"></span>'
-    + '% of images with this slice (right axis)';
+    + '% of images with this slice';
   legend.appendChild(dash);
   container.appendChild(legend);
 }

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_stats_across_dims.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_stats_across_dims.js
@@ -1,10 +1,9 @@
+import { QUALITY_METRIC_INFO, describeQualityMetric } from './plugin_violin.js';
+
 const BASIC_METRIC_BASES = new Set([
   'mean_intensity', 'std_intensity', 'min_intensity', 'max_intensity',
 ]);
-const QUALITY_METRIC_BASES = new Set([
-  'michelson_contrast', 'mscn_variance', 'texture_heterogeneity', 'laplacian_variance',
-  'blocking_index', 'ringing_index',
-]);
+const QUALITY_METRIC_BASES = new Set(Object.keys(QUALITY_METRIC_INFO));
 
 const COL_BG    = ['#ffffff', '#f4f6f9'];
 const MIN_COL_PX = 180;  // min width per "Across 'X' slices" column in the grid
@@ -170,7 +169,7 @@ function buildStatsLayout(ctx) {
 
 // Build the dimension × metric table of mini scatter plots; returns the plot count.
 function renderMetricGrid(tableHost, ctx, { metrics, dimLettersVisible, dimAggMap, layout }, selected) {
-  const { niceName } = ctx.plot;
+  const { niceName, escapeHtml } = ctx.plot;
   tableHost.innerHTML = '';
   const metricsToRender = selected === '__all__' ? metrics : [selected];
   const plotJobs = [];
@@ -199,7 +198,9 @@ function renderMetricGrid(tableHost, ctx, { metrics, dimLettersVisible, dimAggMa
     const titleCell = tbody.insertRow().insertCell();
     titleCell.colSpan = dimLettersVisible.length;
     titleCell.style.cssText = 'font-weight:500;font-size:0.95rem;color:#343a40;padding:5px 10px;border-top:1px solid #e9ecef;background:#f8f9fa';
-    titleCell.textContent = niceName(metric);
+    const metricInfo = ctx.state.showInfo ? describeQualityMetric(metric) : null;
+    titleCell.innerHTML = escapeHtml(niceName(metric))
+      + (metricInfo ? ` <span class="plot-side-info-inline">${escapeHtml(metricInfo.desc)}</span>` : '');
 
     const plotRow = tbody.insertRow();
     dimLettersVisible.forEach((letter, ci) => {

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_summary.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_summary.js
@@ -4,8 +4,8 @@ export default {
   inputs: ['path', 'n_images'],
   label: 'File Data Summary',
   group: 'Summary',
-  info: 'High-level overview of the dataset: total files, total size, file types present, ' +
-    'and (when grouped) a per-group breakdown.',
+  info: 'High-level overview of the dataset: total number of files and images, total size, ' +
+    'file extensions, and (when grouped) a per-group breakdown.',
 
   requires(schema) {
     return schema.allCols.includes('size_bytes') &&

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_violin.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_violin.js
@@ -3,17 +3,53 @@ const BASIC_METRIC_BASES = new Set([
   'mean_intensity', 'std_intensity', 'min_intensity', 'max_intensity',
 ]);
 
-// Matches QualityMetricsProcessor.OUTPUT_SCHEMA + CompressionMetricsProcessor.OUTPUT_SCHEMA
-const QUALITY_METRIC_BASES = new Set([
-  'michelson_contrast', 'mscn_variance', 'texture_heterogeneity', 'laplacian_variance',
-  'blocking_index', 'ringing_index',
-]);
+// Matches QualityMetricsProcessor.OUTPUT_SCHEMA + CompressionMetricsProcessor.OUTPUT_SCHEMA.
+// One description per metric, reused both in the widget-level info panel's
+// bullet list below and as each metric's own per-plot side note. Exported so
+// plugin_stats_across_dims.js (the other quality-metric widget) can reuse it
+// instead of duplicating it.
+export const QUALITY_METRIC_INFO = {
+  michelson_contrast: {
+    label: 'Michelson contrast',
+    desc: 'Global contrast ratio; higher values indicate greater dynamic range.',
+  },
+  mscn_variance: {
+    label: 'MSCN variance',
+    desc: 'Mean Subtracted Contrast Normalized variance; sensitive to noise and blur.',
+  },
+  texture_heterogeneity: {
+    label: 'Texture heterogeneity',
+    desc: 'Coefficient of variation of local standard deviations; captures spatial non-uniformity of texture.',
+  },
+  laplacian_variance: {
+    label: 'Laplacian variance',
+    desc: 'Variance of the discrete Laplacian; higher values indicate a sharper image. Scale-dependent: values vary with bit depth.',
+  },
+  blocking_index: {
+    label: 'Blocking index',
+    desc: 'Strength of blocky compression artifacts (e.g. JPEG blocking).',
+  },
+  ringing_index: {
+    label: 'Ringing index',
+    desc: 'Edge oscillation artifacts around sharp boundaries, often due to compression.',
+  },
+};
+
+const QUALITY_METRIC_BASES = new Set(Object.keys(QUALITY_METRIC_INFO));
 
 function matchesBases(col, bases) {
   for (const base of bases) {
     if (col === base || col.startsWith(base + '_')) return true;
   }
   return false;
+}
+
+/** Look up a quality metric's shared metadata by column name, stripping any per-channel suffix. */
+export function describeQualityMetric(col) {
+  for (const [base, info] of Object.entries(QUALITY_METRIC_INFO)) {
+    if (col === base || col.startsWith(base + '_')) return info;
+  }
+  return null;
 }
 
 const SIGNIFICANCE_HELP = [
@@ -59,12 +95,7 @@ const QUALITY_INFO = [
   '', DISTRIBUTION_HELP,
   '', GRANULARITY_HELP,
   '', '**Metrics**',
-  '- **Michelson contrast** – Global contrast ratio; higher values indicate greater dynamic range.',
-  '- **MSCN variance** – Mean Subtracted Contrast Normalized variance; sensitive to noise and blur.',
-  '- **Texture heterogeneity** – Coefficient of variation of local standard deviations; captures spatial non-uniformity of texture.',
-  '- **Laplacian variance** – Variance of the discrete Laplacian; higher values indicate a sharper image. Scale-dependent: values vary with bit depth.',
-  '- **Blocking index** – Strength of blocky compression artifacts (e.g. JPEG blocking).',
-  '- **Ringing index** – Edge oscillation artifacts around sharp boundaries, often due to compression.',
+  ...Object.values(QUALITY_METRIC_INFO).map(m => `- **${m.label}** – ${m.desc}`),
   '', SIGNIFICANCE_HELP,
 ].join('\n');
 
@@ -188,6 +219,7 @@ async function renderViolins(plotRoot, ctx, filterMetric, splitDims) {
         categoriesOrder: groups,
         catLabelFn: ctx.groupLabel,
         stats,
+        sideInfo: describeQualityMetric(metric)?.desc,
       });
     }
   }

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_violin.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_violin.js
@@ -4,34 +4,34 @@ const BASIC_METRIC_BASES = new Set([
 ]);
 
 // Matches QualityMetricsProcessor.OUTPUT_SCHEMA + CompressionMetricsProcessor.OUTPUT_SCHEMA.
-// One description per metric, reused both in the widget-level info panel's
-// bullet list below and as each metric's own per-plot side note. Exported so
-// plugin_stats_across_dims.js (the other quality-metric widget) can reuse it
-// instead of duplicating it.
+// One description per metric, used as each metric's own per-plot side note (and
+// by plugin_stats_across_dims.js, the other quality-metric widget, so it isn't
+// duplicated there). `hintUp`/`hintDown`/`goodDirection` are only set where the
+// reading is a well-established, monotonic one - see the research this was based
+// on before adding more: mscn_variance's distortion sensitivity isn't monotonic
+// (noise raises it, blur lowers it) and michelson_contrast here isn't even the
+// standard Michelson formula, so neither gets a direction claim.
 export const QUALITY_METRIC_INFO = {
   michelson_contrast: {
-    label: 'Michelson contrast',
     desc: 'Global contrast ratio; higher values indicate greater dynamic range.',
   },
   mscn_variance: {
-    label: 'MSCN variance',
     desc: 'Mean Subtracted Contrast Normalized variance; sensitive to noise and blur.',
   },
   texture_heterogeneity: {
-    label: 'Texture heterogeneity',
     desc: 'Coefficient of variation of local standard deviations; captures spatial non-uniformity of texture.',
   },
   laplacian_variance: {
-    label: 'Laplacian variance',
     desc: 'Variance of the discrete Laplacian; higher values indicate a sharper image. Scale-dependent: values vary with bit depth.',
+    hintUp: 'sharper', hintDown: 'blurrier', goodDirection: 'up',
   },
   blocking_index: {
-    label: 'Blocking index',
     desc: 'Strength of blocky compression artifacts (e.g. JPEG blocking).',
+    hintUp: 'more blocking', hintDown: 'less blocking', goodDirection: 'down',
   },
   ringing_index: {
-    label: 'Ringing index',
     desc: 'Edge oscillation artifacts around sharp boundaries, often due to compression.',
+    hintUp: 'more ringing', hintDown: 'less ringing', goodDirection: 'down',
   },
 };
 
@@ -52,38 +52,34 @@ export function describeQualityMetric(col) {
   return null;
 }
 
+/** Build a renderDistribution `sideInfo` object for a quality metric column, or null. */
+function sideInfoFor(col) {
+  const info = describeQualityMetric(col);
+  return info && {
+    text: info.desc, hintUp: info.hintUp, hintDown: info.hintDown, goodDirection: info.goodDirection,
+  };
+}
+
 const SIGNIFICANCE_HELP = [
   '**Statistical Comparisons**',
   '',
-  'Pairwise group comparisons use the Mann–Whitney U test (a non-parametric test that makes no assumptions about the data distribution) with Bonferroni correction for multiple comparisons.',
+  'If selected (side menu), pairwise group comparisons use the Mann–Whitney U test (a non-parametric test that makes no assumptions about the data distribution) with Bonferroni correction for multiple comparisons.',
   '',
-  '**Significance levels:**',
-  '- `ns`: not significant (p ≥ 0.05)',
-  '- `*`: p < 0.05',
-  '- `**`: p < 0.01',
-  '- `***`: p < 0.001',
+  'Significance levels: `ns` not significant (p ≥ 0.05), `*` p < 0.05, `**` p < 0.01, `***` p < 0.001.',
 ].join('\n');
 
 // Mirrors plot-engine.js MAX_VIOLIN_POINTS - kept here only for the help text.
 const MAX_VIOLIN_POINTS = 5000;
 
 const DISTRIBUTION_HELP = `Plots with ${MAX_VIOLIN_POINTS.toLocaleString()} or fewer datapoints show the actual ` +
-  'distribution shape (a violin); larger plots switch to a summary box plot (quartiles, min/max, ' +
-  'mean) computed directly in the database for performance.';
+  'distribution shape (a violin); larger plots switch to a summary box plot (quartiles, min/max, mean).';
 
-const GRANULARITY_HELP = 'For datasets with multiple dimensions (channels, Z-planes, timepoints, ' +
-  'spatial tiles, …), use the **Slice by** toggles above to control what one datapoint represents - ' +
-  'shown by the **per image** / **per slice** badge in the card header. With nothing toggled, each ' +
-  'point is one whole-image aggregate (**per image**). Switching a toggle on stops that dimension ' +
-  'from being aggregated away, so each point becomes one (image × that dimension) combination instead ' +
-  '(**per slice**) - e.g. switching on "C" gives one point per C-slice per image. Switching on ' +
-  'more dimensions multiplies the number of points, so check the sample size shown in the plot ' +
-  'subtitle before trusting significance results.';
+const GRANULARITY_HELP = 'Use the **Slice by** toggles to control whether each datapoint is a whole-image ' +
+  'aggregate (**per image**) or one (image × dimension) combination (**per slice**) - shown by the badge in the ' +
+  'card header. More toggles mean more datapoints, so check the sample size in the plot subtitle before trusting significance.';
 
 const BASIC_INFO = [
   'Shows **per-image intensity statistics** across groups.',
-  '', 'You can choose which statistic to plot and filter by image dimensions.',
-  '', 'Each plot shows the distribution per group: median, quartiles, min/max, and mean.',
   '', DISTRIBUTION_HELP,
   '', GRANULARITY_HELP,
   '', SIGNIFICANCE_HELP,
@@ -91,11 +87,8 @@ const BASIC_INFO = [
 
 const QUALITY_INFO = [
   'Visualizes **image quality metrics** across groups.',
-  '', 'Use these plots to quickly spot outliers, compare image sets, and detect quality differences.',
   '', DISTRIBUTION_HELP,
   '', GRANULARITY_HELP,
-  '', '**Metrics**',
-  ...Object.values(QUALITY_METRIC_INFO).map(m => `- **${m.label}** – ${m.desc}`),
   '', SIGNIFICANCE_HELP,
 ].join('\n');
 
@@ -219,7 +212,7 @@ async function renderViolins(plotRoot, ctx, filterMetric, splitDims) {
         categoriesOrder: groups,
         catLabelFn: ctx.groupLabel,
         stats,
-        sideInfo: describeQualityMetric(metric)?.desc,
+        sideInfo: sideInfoFor(metric),
       });
     }
   }

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -56,6 +56,10 @@
           <span class="view-label">Full</span><span class="view-icon" aria-hidden="true">▤</span>
         </button>
       </div>
+      <button id="info-toggle-btn" type="button" class="info-toggle-btn" aria-pressed="true" hidden
+              title="Show plot info panels" aria-label="Show plot info panels">
+        <span class="widget-info-icon" aria-hidden="true">ⓘ</span>
+      </button>
       <button id="collapse-all-btn" type="button" class="btn btn-sm btn-outline-secondary" hidden>
         <i class="bi bi-arrows-collapse"></i><span class="d-none d-sm-inline ms-1">Collapse all</span>
       </button>

--- a/viewer/src/__tests__/plugin-groups.test.js
+++ b/viewer/src/__tests__/plugin-groups.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { pluginGroup, orderedGroupNames, groupPlugins } from '../plugin-groups.js';
+
+describe('pluginGroup', () => {
+  it('canonicalizes a known group regardless of case', () => {
+    expect(pluginGroup({ group: 'dataset stats' })).toBe('Dataset Stats');
+  });
+
+  it('falls back to "Other Widgets" for an unset group', () => {
+    expect(pluginGroup({})).toBe('Other Widgets');
+  });
+
+  it('passes through an unknown group name as-is', () => {
+    expect(pluginGroup({ group: 'Third Party' })).toBe('Third Party');
+  });
+});
+
+describe('orderedGroupNames', () => {
+  it('orders known groups per GROUP_ORDER and unknown groups alphabetically after', () => {
+    const plugins = [
+      { group: 'Visualization' }, { group: 'Zeta' }, { group: 'Summary' }, { group: 'Alpha' },
+    ];
+    expect(orderedGroupNames(plugins)).toEqual(['Summary', 'Visualization', 'Alpha', 'Zeta']);
+  });
+});
+
+describe('groupPlugins', () => {
+  it('sorts Dataset Stats plugins per the explicit WIDGET_ORDER regardless of input order', () => {
+    const plugins = [
+      { id: 'stats-across-dims-basic', group: 'Dataset Stats' },
+      { id: 'stats-across-dims-quality', group: 'Dataset Stats' },
+      { id: 'violin-basic', group: 'Dataset Stats' },
+      { id: 'violin-quality', group: 'Dataset Stats' },
+    ];
+    const grouped = groupPlugins(plugins);
+    expect(grouped.get('Dataset Stats').map(p => p.id)).toEqual([
+      'violin-basic', 'violin-quality', 'stats-across-dims-basic', 'stats-across-dims-quality',
+    ]);
+  });
+
+  it('appends plugins not in WIDGET_ORDER after the listed ones, keeping their relative order', () => {
+    const plugins = [
+      { id: 'stats-across-dims-basic', group: 'Dataset Stats' },
+      { id: 'third-party-b', group: 'Dataset Stats' },
+      { id: 'violin-basic', group: 'Dataset Stats' },
+      { id: 'third-party-a', group: 'Dataset Stats' },
+    ];
+    const grouped = groupPlugins(plugins);
+    expect(grouped.get('Dataset Stats').map(p => p.id)).toEqual([
+      'violin-basic', 'stats-across-dims-basic', 'third-party-b', 'third-party-a',
+    ]);
+  });
+
+  it('leaves registration order untouched for groups with no explicit WIDGET_ORDER', () => {
+    const plugins = [
+      { id: 'z', group: 'Summary' },
+      { id: 'a', group: 'Summary' },
+    ];
+    const grouped = groupPlugins(plugins);
+    expect(grouped.get('Summary').map(p => p.id)).toEqual(['z', 'a']);
+  });
+
+  it('does not mutate the input array', () => {
+    const plugins = [
+      { id: 'stats-across-dims-basic', group: 'Dataset Stats' },
+      { id: 'violin-basic', group: 'Dataset Stats' },
+    ];
+    const snapshot = [...plugins];
+    groupPlugins(plugins);
+    expect(plugins).toEqual(snapshot);
+  });
+});

--- a/viewer/src/__tests__/url-params.test.js
+++ b/viewer/src/__tests__/url-params.test.js
@@ -99,10 +99,10 @@ describe('writeUrlParams', () => {
 
   it('omits filter params when filter is empty/missing', () => {
     writeUrlParams({ filter: { col: '', op: '', val: '' } });
-    const search = window.location.search;
-    expect(search).not.toContain('fc=');
-    expect(search).not.toContain('fo=');
-    expect(search).not.toContain('fv=');
+    const params = new URLSearchParams(window.location.search);
+    expect(params.has('fc')).toBe(false);
+    expect(params.has('fo')).toBe(false);
+    expect(params.has('fv')).toBe(false);
   });
 
   it('writes sig=1 when showSignificance is true', () => {

--- a/viewer/src/controls.js
+++ b/viewer/src/controls.js
@@ -1,7 +1,7 @@
 import { state, setState, resetState, emit } from './state.js';
 import { BLOB_COLS } from './schema.js';
 import { getPaletteNames } from './colors.js';
-import { pluginGroup, orderedGroupNames } from './plugin-groups.js';
+import { orderedGroupNames, groupPlugins } from './plugin-groups.js';
 import { formatFrozenSidebarHtml } from './export-snapshot.js';
 import { escapeHtml } from './plot-utils.js';
 
@@ -218,12 +218,7 @@ function buildWidgetToggles(plugins, schema) {
     return;
   }
 
-  const grouped = new Map();
-  for (const p of applicable) {
-    const grp = pluginGroup(p);
-    if (!grouped.has(grp)) grouped.set(grp, []);
-    grouped.get(grp).push(p);
-  }
+  const grouped = groupPlugins(applicable);
   const orderedGroups = orderedGroupNames(applicable);
 
   container.innerHTML = orderedGroups.map(g => {

--- a/viewer/src/controls.js
+++ b/viewer/src/controls.js
@@ -25,21 +25,44 @@ let syncViewToggle = () => {};
 export function initStaticUi() {
   const viewBtnOverview = el('view-btn-overview');
   const viewBtnFull     = el('view-btn-full');
+  // Master info switch only makes sense in Full view - Overview shows tiles,
+  // not cards, so there are no info panels to toggle by default.
+  const infoBtn = el('info-toggle-btn');
   syncViewToggle = () => {
     viewBtnOverview?.setAttribute('aria-pressed', String(state.overviewMode));
     viewBtnFull?.setAttribute('aria-pressed',     String(!state.overviewMode));
+    if (infoBtn) {
+      infoBtn.hidden = state.overviewMode;
+      infoBtn.setAttribute('aria-pressed', String(state.showInfo));
+    }
   };
   if (viewBtnOverview && viewBtnFull) {
     syncViewToggle();
     viewBtnOverview.onclick = () => { if (state.overviewMode) return; state.overviewMode = true;  syncViewToggle(); emit('render'); };
     viewBtnFull.onclick     = () => { if (!state.overviewMode) return; state.overviewMode = false; syncViewToggle(); emit('render'); };
   }
+
+  // Master switch for widget info panels' default open/closed state. Each
+  // card's own ⓘ button still lets a user override this per widget.
+  if (infoBtn) {
+    infoBtn.setAttribute('aria-pressed', String(state.showInfo));
+    infoBtn.onclick = () => {
+      state.showInfo = !state.showInfo;
+      infoBtn.setAttribute('aria-pressed', String(state.showInfo));
+      emit('render');
+    };
+  }
+
   initCollapseToggle('appearance-section-header', 'appearance-section');
   initHeaderPopover('export-menu-btn', 'export-menu-panel');
   initHeaderPopover('feedback-menu-btn', 'feedback-menu-panel');
 }
 
 export function initControls(schema, totalRows, plugins, onExport, canParquet, opts = {}) {
+  // View mode / info toggle may have been overridden by URL params after
+  // initStaticUi() ran with defaults - resync their DOM now.
+  syncViewToggle();
+
   // ── Palette ──────────────────────────────────────────────────────────
   const paletteEl = el('palette-selector');
   paletteEl.innerHTML = getPaletteNames().map(p => opt(p, p)).join('');

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -313,6 +313,7 @@ function afterLoad(options = {}) {
   if (urlParams.dimensions)       state.dimensions       = urlParams.dimensions;
   if ('showSignificance' in urlParams) state.showSignificance = urlParams.showSignificance;
   if ('overviewMode' in urlParams)     state.overviewMode     = urlParams.overviewMode;
+  if ('showInfo' in urlParams)          state.showInfo          = urlParams.showInfo;
   if (urlParams.hiddenWidgets)    state.hiddenWidgets    = urlParams.hiddenWidgets;
   if (urlParams.openedWidgets)    state.openedWidgets    = urlParams.openedWidgets;
 

--- a/viewer/src/plot-engine.js
+++ b/viewer/src/plot-engine.js
@@ -235,6 +235,8 @@ const STAT_SELECT = (q, num) => `
  *                     metric means) - rendered in a column beside the plot, always
  *                     visible. Distinct from the widget-level ⓘ panel, which explains
  *                     the widget as a whole and can't say something different per plot.
+ *                     Pass a string, or an object to also show a ▲/▼ direction
+ *                     badge - see appendSideInfoRow in plot-utils.js.
  *
  * Returns true if anything was drawn, false otherwise.
  */

--- a/viewer/src/plot-engine.js
+++ b/viewer/src/plot-engine.js
@@ -17,7 +17,7 @@
 
 // plot-utils is bundled into the same app chunk (not a plugin), so importing it
 // here is safe in offline mode - only package plugins can't use sibling imports.
-import { statTable } from './plot-utils.js';
+import { statTable, appendSideInfoRow } from './plot-utils.js';
 export { statTable };
 
 // ── Constants ───────────────────────────────────────────────────────────────
@@ -231,6 +231,10 @@ const STAT_SELECT = (q, num) => `
  *   layout?           extra Plotly layout merged over the computed one (height,
  *                     margin, title font, …) - for compact grid cells
  *   divStyle?         wrapper element style string (e.g. flex sizing in a grid)
+ *   sideInfo?         short markdown note specific to this one plot (e.g. what this
+ *                     metric means) - rendered in a column beside the plot, always
+ *                     visible. Distinct from the widget-level ⓘ panel, which explains
+ *                     the widget as a whole and can't say something different per plot.
  *
  * Returns true if anything was drawn, false otherwise.
  */
@@ -242,6 +246,7 @@ export async function renderDistribution(container, ctx, spec) {
     maxRawPoints = MAX_VIOLIN_POINTS, series, categoriesOrder = null,
     catLabelFn = (v) => v, stats: precomputed = null, isStale = () => false,
     allPointsBelow = VIOLIN_ALL_POINTS_BELOW, layout: layoutOverride = {}, divStyle = '',
+    sideInfo = null,
   } = spec;
   const { table, where } = source;
 
@@ -311,7 +316,8 @@ export async function renderDistribution(container, ctx, spec) {
   };
   // Keep the computed title text when the caller only overrides its styling (font, …).
   if (title && layoutOverride.title) finalLayout.title = { text: title, ...layoutOverride.title };
-  const plotDiv = ctx.plot.append(container, traces, finalLayout, divStyle);
+  const plotContainer = (sideInfo && ctx.state.showInfo) ? appendSideInfoRow(container, sideInfo) : container;
+  const plotDiv = ctx.plot.append(plotContainer, traces, finalLayout, divStyle);
 
   // Significance only makes sense with one violin/box per X category: either
   // category mode, or a single color series. Keyed on raw category values;

--- a/viewer/src/plot-utils.js
+++ b/viewer/src/plot-utils.js
@@ -211,10 +211,17 @@ export function renderInfoHtml(text) {
 }
 
 function mdInline(t) {
-  return t
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-    .replace(/`(.+?)`/g, '<code>$1</code>');
+  // Protect code spans before the bold pass, so literal `**`/`***` inside
+  // backticks (e.g. significance-level markers) aren't consumed as bold
+  // delimiters and swallowed.
+  const codeSpans = [];
+  const escaped = t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const withPlaceholders = escaped.replace(/`([^`]+?)`/g, (_, code) => {
+    codeSpans.push(code);
+    return `\x00${codeSpans.length - 1}\x00`;
+  });
+  const bolded = withPlaceholders.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  return bolded.replace(/\x00(\d+)\x00/g, (_, i) => `<code>${codeSpans[Number(i)]}</code>`);
 }
 
 /**
@@ -224,10 +231,17 @@ function mdInline(t) {
  * grid. `container` must already be attached to the DOM (see appendPlot).
  *
  * @param {HTMLElement} container
- * @param {string} infoText  Markdown-lite note, rendered via renderInfoHtml.
+ * @param {string|{text: string, hintUp?: string, hintDown?: string, goodDirection?: 'up'|'down'}} info
+ *   Markdown-lite note, rendered via renderInfoHtml. Pass an object instead of a
+ *   plain string to also show a two-line ▲/▼ direction badge (e.g. "▲ more
+ *   ringing" / "▼ less ringing") - only set these when the reading is a
+ *   well-established, monotonic one; omit them rather than guess. `goodDirection`
+ *   just picks which line is colored green vs red.
  * @returns {HTMLElement} the plot column - render your chart into this, not `container`.
  */
-export function appendSideInfoRow(container, infoText) {
+export function appendSideInfoRow(container, info) {
+  const { text, hintUp, hintDown, goodDirection } = typeof info === 'string' ? { text: info } : info;
+
   const row = document.createElement('div');
   // flex-wrap so the note drops below the plot instead of squeezing it when
   // the grid cell is too narrow to fit both side by side.
@@ -236,7 +250,19 @@ export function appendSideInfoRow(container, infoText) {
 
   const infoCol = document.createElement('div');
   infoCol.className = 'plot-side-info';
-  infoCol.innerHTML = renderInfoHtml(infoText);
+  if (hintUp && hintDown) {
+    const badge = document.createElement('div');
+    badge.className = 'plot-side-info-direction';
+    const upClass   = goodDirection === 'up'   ? 'plot-side-info-good' : 'plot-side-info-bad';
+    const downClass = goodDirection === 'down' ? 'plot-side-info-good' : 'plot-side-info-bad';
+    badge.innerHTML =
+      `<div class="${upClass}"><span aria-hidden="true">▲</span> ${escapeHtml(hintUp)}</div>` +
+      `<div class="${downClass}"><span aria-hidden="true">▼</span> ${escapeHtml(hintDown)}</div>`;
+    infoCol.appendChild(badge);
+  }
+  const body = document.createElement('div');
+  body.innerHTML = renderInfoHtml(text);
+  infoCol.appendChild(body);
   row.appendChild(infoCol);
 
   const plotCol = document.createElement('div');

--- a/viewer/src/plot-utils.js
+++ b/viewer/src/plot-utils.js
@@ -195,6 +195,58 @@ export function escapeHtml(s) {
 }
 
 /**
+ * Minimal markdown → HTML converter for widget info panels and plot side-info
+ * notes: paragraphs/bullets, **bold**, and `code`.
+ */
+export function renderInfoHtml(text) {
+  let html = '';
+  for (const para of text.trim().split(/\n\n+/)) {
+    const lines = para.split('\n');
+    const bullets = lines.filter(l => /^\s*-\s/.test(l));
+    const prose   = lines.filter(l => !/^\s*-\s/.test(l));
+    if (prose.length)   html += `<p>${prose.map(mdInline).join('<br>')}</p>`;
+    if (bullets.length) html += `<ul>${bullets.map(l => `<li>${mdInline(l.replace(/^\s*-\s*/, ''))}</li>`).join('')}</ul>`;
+  }
+  return html;
+}
+
+function mdInline(t) {
+  return t
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/`(.+?)`/g, '<code>$1</code>');
+}
+
+/**
+ * Split `container` into a [plot | info] row and return the plot column for the
+ * caller to render into. Used when a single plot (not the whole widget) needs
+ * its own short explanatory note beside it - e.g. one metric in a multi-plot
+ * grid. `container` must already be attached to the DOM (see appendPlot).
+ *
+ * @param {HTMLElement} container
+ * @param {string} infoText  Markdown-lite note, rendered via renderInfoHtml.
+ * @returns {HTMLElement} the plot column - render your chart into this, not `container`.
+ */
+export function appendSideInfoRow(container, infoText) {
+  const row = document.createElement('div');
+  // flex-wrap so the note drops below the plot instead of squeezing it when
+  // the grid cell is too narrow to fit both side by side.
+  row.style.cssText = 'display:flex;flex-wrap:wrap;gap:10px;align-items:stretch;width:100%';
+  container.appendChild(row);
+
+  const infoCol = document.createElement('div');
+  infoCol.className = 'plot-side-info';
+  infoCol.innerHTML = renderInfoHtml(infoText);
+  row.appendChild(infoCol);
+
+  const plotCol = document.createElement('div');
+  plotCol.style.cssText = 'flex:1 1 240px;min-width:0';
+  row.appendChild(plotCol);
+
+  return plotCol;
+}
+
+/**
  * Bargap for bar charts - mirrors Dash _apply_standard_styling.
  *   1 category → 0.7,  2 → 0.4,  3+ → 0.1
  */

--- a/viewer/src/plugin-groups.js
+++ b/viewer/src/plugin-groups.js
@@ -1,5 +1,15 @@
 const GROUP_ORDER = ['Summary', 'File Stats', 'Metadata', 'Dataset Stats', 'Visualization', 'Other Widgets'];
 
+// Explicit widget order within a group, by plugin id. Without this, order
+// within a group just falls out of plugin *registration* order, which for
+// auto_detect extensions is an alphabetical glob of plugin_*.js filenames -
+// an accident of naming, not a real ordering decision (e.g. it put "stats
+// across dims" before "violin" purely because "s" < "v"). Anything not
+// listed here keeps its registration order, appended after the listed ones.
+const WIDGET_ORDER = {
+  'Dataset Stats': ['violin-basic', 'violin-quality', 'stats-across-dims-basic', 'stats-across-dims-quality'],
+};
+
 const CANON = new Map(GROUP_ORDER.map(g => [g.toLowerCase(), g]));
 
 export function pluginGroup(plugin) {
@@ -14,5 +24,29 @@ export function orderedGroupNames(plugins) {
     ...GROUP_ORDER.filter(g => names.includes(g)),
     ...names.filter(g => !GROUP_ORDER.includes(g)).sort(),
   ];
+}
+
+/**
+ * Group plugins by their canonical group (Map<groupName, plugin[]>, insertion
+ * order = first-seen group order). Within each group, plugins are sorted per
+ * WIDGET_ORDER when that group has an explicit order; otherwise they keep
+ * registration order. The sort is stable, so unlisted plugins in an ordered
+ * group keep their relative registration order too, appended after the
+ * listed ones.
+ */
+export function groupPlugins(plugins) {
+  const grouped = new Map();
+  for (const p of plugins) {
+    const g = pluginGroup(p);
+    if (!grouped.has(g)) grouped.set(g, []);
+    grouped.get(g).push(p);
+  }
+  for (const [g, list] of grouped) {
+    const order = WIDGET_ORDER[g];
+    if (!order) continue;
+    const rank = id => { const i = order.indexOf(id); return i === -1 ? order.length : i; };
+    list.sort((a, b) => rank(a.id) - rank(b.id));
+  }
+  return grouped;
 }
 

--- a/viewer/src/renderer.js
+++ b/viewer/src/renderer.js
@@ -563,7 +563,7 @@ function createCard(label, info, scope) {
   if (info) {
     panel = document.createElement('div');
     panel.className = 'widget-info-panel';
-    panel.hidden = true;
+    panel.hidden = !state.showInfo;
     panel.innerHTML = renderInfoHtml(info);
 
     const btn = document.createElement('button');
@@ -571,8 +571,12 @@ function createCard(label, info, scope) {
     btn.className = 'widget-info-btn';
     btn.title = 'About this widget';
     btn.setAttribute('aria-label', 'About this widget');
+    btn.setAttribute('aria-pressed', String(!panel.hidden));
     btn.innerHTML = '<span class="widget-info-icon" aria-hidden="true">ⓘ</span>';
-    btn.addEventListener('click', () => { panel.hidden = !panel.hidden; });
+    btn.addEventListener('click', () => {
+      panel.hidden = !panel.hidden;
+      btn.setAttribute('aria-pressed', String(!panel.hidden));
+    });
     titleWrap.appendChild(btn);
   }
 

--- a/viewer/src/renderer.js
+++ b/viewer/src/renderer.js
@@ -2,7 +2,7 @@ import { buildColorMap, groupColor as _groupColor, hexToRgba, getColors, getPale
 import { GROUP_ALL, GROUP_COL_ALIAS, WIDGET_CONTAINER_ID } from './constants.js';
 import { buildWhere, q as _q, sample, andWhere, groupCol as _groupCol, groupExpr as _groupExpr, dimSubsetWhere, stripWhere } from './sql.js';
 import { buildScopedWhere } from './cohort-sql.js';
-import { appendPlot, appendPlots, appendMiniPlot, niceName, escapeHtml, bargap, createFlexGrid, sliceToggles, appendGroupLegend, prependWarning, dtypeRange, dataAvailabilityWarning, groupingLabel, legendWithGrouping, formatBytes, humanList, statTable, appendInvariantTable, tilePreviewTable, LEGEND, LAYOUT } from './plot-utils.js';
+import { appendPlot, appendPlots, appendMiniPlot, niceName, escapeHtml, bargap, createFlexGrid, sliceToggles, appendGroupLegend, prependWarning, dtypeRange, dataAvailabilityWarning, groupingLabel, legendWithGrouping, formatBytes, humanList, statTable, appendInvariantTable, tilePreviewTable, renderInfoHtml, LEGEND, LAYOUT } from './plot-utils.js';
 import * as plotEngine from './plot-engine.js';
 import { META_COLS } from './schema.js';
 import { updateFilteredInfo } from './controls.js';
@@ -595,28 +595,8 @@ function createCard(label, info, scope) {
   return div;
 }
 
-/** Minimal markdown → HTML converter for info panel text. */
-function renderInfoHtml(text) {
-  let html = '';
-  for (const para of text.trim().split(/\n\n+/)) {
-    const lines = para.split('\n');
-    const bullets = lines.filter(l => /^\s*-\s/.test(l));
-    const prose   = lines.filter(l => !/^\s*-\s/.test(l));
-    if (prose.length)   html += `<p>${prose.map(mdInline).join('<br>')}</p>`;
-    if (bullets.length) html += `<ul>${bullets.map(l => `<li>${mdInline(l.replace(/^\s*-\s*/, ''))}</li>`).join('')}</ul>`;
-  }
-  return html;
-}
-
 function sortGroups(groups) {
   const allNumeric = groups.length > 0 && groups.every(g => g !== '' && !isNaN(Number(g)));
   if (allNumeric) return [...groups].sort((a, b) => Number(a) - Number(b));
   return [...groups].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-}
-
-function mdInline(t) {
-  return t
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-    .replace(/`(.+?)`/g, '<code>$1</code>');
 }

--- a/viewer/src/renderer.js
+++ b/viewer/src/renderer.js
@@ -8,7 +8,7 @@ import { META_COLS } from './schema.js';
 import { updateFilteredInfo } from './controls.js';
 import { state } from './state.js';
 import { writeUrlParams } from './url-params.js';
-import { pluginGroup, orderedGroupNames } from './plugin-groups.js';
+import { pluginGroup, orderedGroupNames, groupPlugins } from './plugin-groups.js';
 import { buildGroupLabels } from './group-labels.js';
 import { scopeBadgeHtml, setScopeBadge } from './scopes.js';
 
@@ -307,12 +307,7 @@ async function renderPluginBody(plugin, body, ctx) {
  * rendered as a full, always-expanded card.
  */
 async function renderClassic(container, activePlugins, ctx) {
-  const grouped = new Map();
-  for (const plugin of activePlugins) {
-    const grp = pluginGroup(plugin);
-    if (!grouped.has(grp)) grouped.set(grp, []);
-    grouped.get(grp).push(plugin);
-  }
+  const grouped = groupPlugins(activePlugins);
   const orderedGroups = orderedGroupNames(activePlugins);
 
   for (const groupName of orderedGroups) {
@@ -332,12 +327,7 @@ async function renderClassic(container, activePlugins, ctx) {
 // Plugins ordered by their group's canonical order, so related tiles cluster
 // in the gallery even though the section headers are dropped.
 function orderActivePlugins(activePlugins) {
-  const grouped = new Map();
-  for (const p of activePlugins) {
-    const g = pluginGroup(p);
-    if (!grouped.has(g)) grouped.set(g, []);
-    grouped.get(g).push(p);
-  }
+  const grouped = groupPlugins(activePlugins);
   const ordered = [];
   for (const g of orderedGroupNames(activePlugins)) ordered.push(...grouped.get(g));
   return ordered;

--- a/viewer/src/state.js
+++ b/viewer/src/state.js
@@ -18,6 +18,8 @@ export const state = {
   openedWidgets:    new Set(), // overview gallery: plugin IDs expanded in place
   /** When true, plugins render an optional friendly intro box before their content. */
   overviewMode:     true,
+  /** Default open/closed state for widget info panels; per-widget ⓘ button can still override. */
+  showInfo:          true,
   /** Offline snapshot bundle: sidebar is read-only and URL sync is disabled */
   sidebarLocked:    false,
 };
@@ -49,6 +51,7 @@ export function resetState(defaultGroupCol) {
   state.dimensions       = {};
   state.showSignificance = false;
   state.overviewMode     = true;
+  state.showInfo          = true;
   state.openedWidgets    = new Set();
   state.hiddenWidgets    = new Set();
   emit('query');

--- a/viewer/src/style.css
+++ b/viewer/src/style.css
@@ -214,6 +214,18 @@ body { background: #f8f9fa; }
 .widget-info-panel ul   { margin: 0 0 4px; padding-left: 20px; }
 .widget-info-panel li   { margin-bottom: 2px; }
 .widget-info-panel code { background: #dceeff; padding: 1px 4px; border-radius: 3px; font-size: 12px; }
+
+/* ── Per-plot side info (short note beside one plot in a multi-plot widget) ── */
+.plot-side-info {
+  flex: 1 1 140px; max-width: 160px; align-self: center; color: #495057;
+  font-size: 12px; line-height: 1.4; padding-left: 4px;
+}
+.plot-side-info p  { margin: 0 0 4px; }
+.plot-side-info code { background: #eef1f4; padding: 1px 4px; border-radius: 3px; font-size: 11px; }
+
+/* Same note, inline variant for row-header layouts (e.g. stats-across-dims). */
+.plot-side-info-inline { font-weight: 400; font-size: 12px; color: #495057; }
+
 .widget-card-body { padding: 16px; }
 
 /* ── Shared widget styles ── */

--- a/viewer/src/style.css
+++ b/viewer/src/style.css
@@ -226,6 +226,13 @@ body { background: #f8f9fa; }
 /* Same note, inline variant for row-header layouts (e.g. stats-across-dims). */
 .plot-side-info-inline { font-weight: 400; font-size: 12px; color: #495057; }
 
+/* Direction badge (▲/▼ + short hint per direction) - only shown for metrics with
+   a well-established, monotonic reading. Green = the "good" direction, red = the
+   direction that indicates a quality issue. */
+.plot-side-info-direction { font-weight: 600; font-size: 12px; margin-bottom: 3px; }
+.plot-side-info-good { color: #198754; }
+.plot-side-info-bad  { color: #dc3545; }
+
 .widget-card-body { padding: 16px; }
 
 /* ── Shared widget styles ── */

--- a/viewer/src/style.css
+++ b/viewer/src/style.css
@@ -200,9 +200,11 @@ body { background: #f8f9fa; }
 .widget-info-btn {
   background: none; border: none; cursor: pointer; flex-shrink: 0;
   display: inline-flex; align-items: center; justify-content: center;
-  color: #6c757d; width: 24px; height: 24px; padding: 0; border-radius: 50%;
+  color: #6c757d; width: 20px; height: 20px; padding: 0; border-radius: 50%;
 }
 .widget-info-btn:hover { color: #0d6efd; background: #eef4ff; }
+.widget-info-btn[aria-pressed="true"] { background: #6c757d; color: #fff; }
+.widget-info-btn[aria-pressed="true"]:hover { background: #5c636a; color: #fff; }
 .widget-info-icon { font-size: 19px; line-height: 1; }
 .widget-info-panel {
   padding: 12px 16px; background: #f0f7ff;
@@ -445,6 +447,17 @@ canvas { image-rendering: pixelated; max-width: 100%; }
   #row-count-badge { display: none !important; }
   .across-dims-wrap { max-width: 100% !important; }
 }
+
+/* ── Info panels master toggle ── */
+.info-toggle-btn {
+  background: none; border: none; cursor: pointer; flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: #6c757d; width: 26px; height: 26px; padding: 0; border-radius: 50%;
+  font-size: 24px; line-height: 1;
+}
+.info-toggle-btn:hover { color: #0d6efd; background: #eef4ff; }
+.info-toggle-btn[aria-pressed="true"] { background: #6c757d; color: #fff; }
+.info-toggle-btn[aria-pressed="true"]:hover { background: #5c636a; color: #fff; }
 
 /* ── Topbar icon + brand ── */
 .topbar-icon  { height: 28px; width: auto; }

--- a/viewer/src/url-params.js
+++ b/viewer/src/url-params.js
@@ -11,6 +11,7 @@ import { DEFAULT_PALETTE } from './constants.js';
  *   dims      - active dimensions, e.g. "c0.t1"  (dot-separated, no encoding needed)
  *   sig       - "1" when significance brackets enabled
  *   view      - "full" when classic full-widget mode is active (absent = overview, the default)
+ *   info      - "0" when widget info panels default to closed (absent = shown, the default)
  *   hidden    - dot-separated hidden widget IDs  (dot-separated, no encoding needed)
  *   opened    - dot-separated widget IDs expanded in the overview gallery
  *   extension - URL of a JSON extension manifest (repeatable); manifest format:
@@ -34,6 +35,7 @@ export function writeUrlParams(state) {
   setOrDelete(params, 'dims',   dimStr || null);
   setOrDelete(params, 'sig',    state.showSignificance ? '1' : null);
   setOrDelete(params, 'view',   state.overviewMode ? null : 'full');
+  setOrDelete(params, 'info',   state.showInfo ? null : '0');
   setOrDelete(params, 'hidden', state.hiddenWidgets?.size > 0
     ? [...state.hiddenWidgets].sort().join('.') : null);
   setOrDelete(params, 'opened', state.openedWidgets?.size > 0
@@ -64,6 +66,7 @@ export function readUrlParams() {
 
   if (params.has('sig'))    out.showSignificance = params.get('sig') === '1';
   if (params.has('view'))   out.overviewMode = params.get('view') !== 'full';
+  if (params.has('info'))   out.showInfo = params.get('info') !== '0';
   if (params.has('hidden')) out.hiddenWidgets = new Set(params.get('hidden').split('.').filter(Boolean));
   if (params.has('opened')) out.openedWidgets = new Set(params.get('opened').split('.').filter(Boolean));
 


### PR DESCRIPTION
Adds a master toggle for widget info panels (topbar, next to the view mode switch), plus a per-plot side note for quality metrics with a direction badge (▲/▼) where the reading is well-established (sharpness, blocking, ringing) — deliberately omitted for metrics where it isn't (contrast, MSCN variance, texture heterogeneity).

Also: reworded several widgets' info text for accuracy, fixed the dim-size widget picking up unrelated size_ columns as dimensions, and fixed widget ordering within a group to not depend on plugin_*.js filename alphabetical order.

plugin_histogram.js was intentionally left untouched — it's being remade in a separate PR.

Closes #158