### PR TITLE
add --view flag to pixel-patrol process

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ pixel-patrol process path/to/images/ -o results.parquet --loader bioio \
 pixel-patrol view results.parquet
 ```
 
+Or combine both steps with `--view`:
+
+```bash
+pixel-patrol process path/to/images/ -o results.parquet --loader bioio --view
+```
+
 **Or use the processing dashboard** for a visual interface:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Or combine both steps with `--view`:
 pixel-patrol process path/to/images/ -o results.parquet --loader bioio --view
 ```
 
+To use viewer parameters, run the two commands sequentially:
+
+```bash
+pixel-patrol process path/to/images/ -o results.parquet --loader bioio && pixel-patrol view results.parquet
+```
+
 **Or use the processing dashboard** for a visual interface:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,6 +42,7 @@ pixel-patrol process BASE_DIRECTORY -o OUTPUT.parquet [OPTIONS]
 | `--parquet-row-group-size N` | 2048 | Rows per row group in the final parquet. Smaller values speed up thumbnail sampling in the viewer. |
 | `--log-file` | off | Write a debug log file alongside the output parquet. |
 | `--omit-base-dir` | off | Do not store the base directory in the parquet metadata. Useful when sharing tables without revealing local filesystem paths. See the [privacy policy](privacy.md). |
+| `--view` | off | Open the viewer immediately after processing completes, using default viewer settings. Equivalent to running `pixel-patrol view OUTPUT` afterwards. |
 
 **Examples**
 
@@ -56,6 +57,9 @@ pixel-patrol process my-data/ -o results.parquet --loader bioio \
 # Large dataset on a cluster:
 pixel-patrol process my-data/ -o results.parquet --loader bioio \
   --scheduler tcp://host:8786 --mb-per-task 128 --log-file
+
+# Process and open the viewer in one step:
+pixel-patrol process my-data/ -o results.parquet --loader bioio --view
 ```
 
 ---

--- a/docs/tutorials/processing.md
+++ b/docs/tutorials/processing.md
@@ -449,6 +449,22 @@ Answer the questions below and we'll walk you through each decision together, bu
       </label>
     </div>
 
+    <!-- Open viewer -->
+    <div class="wiz-adv-field">
+      <div class="wiz-adv-field-label">
+        Open viewer when done <code class="wiz-badge">--view</code>
+      </div>
+      <div class="wiz-adv-field-hint">
+        Opens the interactive report automatically once processing completes, using default viewer settings.
+        Equivalent to running <code>pixel-patrol view results.parquet</code> afterwards.
+      </div>
+      <label class="wiz-option" style="max-width:260px">
+        <input type="checkbox" id="pwi-open_viewer"
+               onchange="procWiz.set('open_viewer', this.checked)">
+        <div><div class="wiz-opt-title">Open viewer after processing</div></div>
+      </label>
+    </div>
+
   </div>
 
 </div>
@@ -481,6 +497,7 @@ const procWiz = {
     max_images_per_task: '',
     rows_per_part:       '',
     log_file:            false,
+    open_viewer:         false,
     output_mode:         'cli',
   },
 
@@ -630,7 +647,9 @@ const procWiz = {
     if (doneText) {
       doneText.innerHTML = (s.output_mode === 'api')
         ? '✓ Your script is ready above - save it (e.g. <code>run_processing.py</code>) and run it with <code>python run_processing.py</code>. It already opens the viewer at the end via <code>api.view(project)</code>.'
-        : '✓ Your command is ready above. Once it finishes, open the interactive report with <code>pixel-patrol view results.parquet</code>.';
+        : s.open_viewer
+          ? '✓ Your command is ready above. The viewer will open automatically when processing completes.'
+          : '✓ Your command is ready above. Once it finishes, open the interactive report with <code>pixel-patrol view results.parquet</code>.';
     }
   },
 
@@ -666,6 +685,7 @@ const procWiz = {
     if (s.max_images_per_task) pp.push('--max-images-per-task ' + s.max_images_per_task);
     if (s.rows_per_part)       pp.push('--rows-per-part ' + s.rows_per_part);
     if (s.log_file)            pp.push('--log-file');
+    if (s.open_viewer)         pp.push('--view');
 
     let lines = [];
     if (isSlurm) {

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/cli.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/cli.py
@@ -82,6 +82,9 @@ def cli():
 @click.option('--omit-base-dir', is_flag=True, default=False,
               help='Do not store the base directory in the parquet metadata. '
                    'Useful when sharing tables without revealing local filesystem paths.')
+@click.option('--view', 'open_viewer', is_flag=True, default=False,
+              help='Open the viewer immediately after processing completes, using default viewer settings. '
+                   'Equivalent to running `pixel-patrol view OUTPUT` afterwards.')
 def process(base_directory: Path, output: Path, name: str | None, paths: tuple[str, ...],
               loader: str, file_extensions: tuple[str, ...],
               flavor: str, description: str,
@@ -94,7 +97,8 @@ def process(base_directory: Path, output: Path, name: str | None, paths: tuple[s
               slice_size: tuple[str, ...],
               rows_per_part: int | None,
               log_file: bool,
-              omit_base_dir: bool):
+              omit_base_dir: bool,
+              open_viewer: bool):
     """
     Scan images in BASE_DIRECTORY, process them, and write a .parquet table.
 
@@ -103,6 +107,11 @@ def process(base_directory: Path, output: Path, name: str | None, paths: tuple[s
     \b
       pixel-patrol process path/to/images/ -o results.parquet --loader bioio
       pixel-patrol view results.parquet
+
+    Or in one step:
+
+    \b
+      pixel-patrol process path/to/images/ -o results.parquet --loader bioio --view
     """
     base_directory = base_directory.resolve()
 
@@ -144,6 +153,10 @@ def process(base_directory: Path, output: Path, name: str | None, paths: tuple[s
     except KeyboardInterrupt:
         click.echo("\nCancelled.")
         raise SystemExit(1)
+
+    resolved_output = output if output.suffix.lower() == ".parquet" else output.with_suffix(".parquet")
+    if open_viewer and resolved_output.exists():
+        api_view(resolved_output)
 
 
 @cli.command()

--- a/packages/pixel-patrol-base/tests/test_cli_paths.py
+++ b/packages/pixel-patrol-base/tests/test_cli_paths.py
@@ -14,10 +14,11 @@ sys.modules.pop("pixel_patrol_base", None)
 from pixel_patrol_base import cli as cli_module
 
 
-def _setup_fake_cli(monkeypatch, dataset_root: Path):
+def _setup_fake_cli(monkeypatch, dataset_root: Path, create_output: bool = False):
     """Wire the CLI entry points to lightweight fakes for deterministic assertions."""
     dummy_project: dict[str, Any] = {}
     added_paths: list[Path] = []
+    view_calls: list[Path] = []
 
     def fake_create_project(name: str, base_dir: str, loader: str | None = None, output_path: str | Path | None = None):
         assert Path(base_dir).resolve() == dataset_root.resolve()
@@ -43,13 +44,19 @@ def _setup_fake_cli(monkeypatch, dataset_root: Path):
         return project
 
     def fake_process_files(project, **kwargs):
+        if create_output and dummy_project.get("output_path"):
+            dummy_project["output_path"].touch()
         return project
+
+    def fake_view(path, **kwargs):
+        view_calls.append(path)
 
     monkeypatch.setattr(cli_module, "create_project", fake_create_project)
     monkeypatch.setattr(cli_module, "add_paths", fake_add_paths)
     monkeypatch.setattr(cli_module, "process_files", fake_process_files)
+    monkeypatch.setattr(cli_module, "api_view", fake_view)
 
-    return added_paths
+    return added_paths, view_calls
 
 
 def test_process_accepts_relative_base_and_paths(monkeypatch, tmp_path):
@@ -63,7 +70,7 @@ def test_process_accepts_relative_base_and_paths(monkeypatch, tmp_path):
 
     output_path = tmp_path / "out.parquet"
 
-    added_paths = _setup_fake_cli(monkeypatch, dataset_root)
+    added_paths, _ = _setup_fake_cli(monkeypatch, dataset_root)
 
     monkeypatch.chdir(dataset_root.parent)
 
@@ -97,7 +104,7 @@ def test_process_accepts_absolute_paths(monkeypatch, tmp_path):
 
     output_path = tmp_path / "out.parquet"
 
-    added_paths = _setup_fake_cli(monkeypatch, dataset_root)
+    added_paths, _ = _setup_fake_cli(monkeypatch, dataset_root)
 
     result = runner.invoke(
         cli_module.cli,
@@ -116,3 +123,63 @@ def test_process_accepts_absolute_paths(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert added_paths == [pngs_dir.resolve(), tifs_dir.resolve()]
+
+
+def test_process_view_flag_opens_viewer(monkeypatch, tmp_path):
+    runner = CliRunner()
+    dataset_root = tmp_path / "dataset"
+    dataset_root.mkdir()
+    output_path = tmp_path / "out.parquet"
+
+    _, view_calls = _setup_fake_cli(monkeypatch, dataset_root, create_output=True)
+
+    result = runner.invoke(
+        cli_module.cli,
+        ["process", str(dataset_root), "-o", str(output_path), "--view"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert view_calls == [output_path]
+
+
+def test_process_view_flag_skipped_when_no_output(monkeypatch, tmp_path):
+    runner = CliRunner()
+    dataset_root = tmp_path / "dataset"
+    dataset_root.mkdir()
+    output_path = tmp_path / "out.parquet"
+
+    _, view_calls = _setup_fake_cli(monkeypatch, dataset_root, create_output=False)
+
+    result = runner.invoke(
+        cli_module.cli,
+        ["process", str(dataset_root), "-o", str(output_path), "--view"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert view_calls == []
+
+
+def test_process_view_flag_corrects_missing_extension(monkeypatch, tmp_path):
+    """--output without .parquet extension should still open the viewer with the corrected path."""
+    runner = CliRunner()
+    dataset_root = tmp_path / "dataset"
+    dataset_root.mkdir()
+    output_no_ext = tmp_path / "out"  # no .parquet
+    output_corrected = tmp_path / "out.parquet"
+
+    _, view_calls = _setup_fake_cli(monkeypatch, dataset_root, create_output=False)
+    # fake_process_files won't create the file; touch it manually to simulate the corrected path
+    output_corrected.touch()
+
+    result = runner.invoke(
+        cli_module.cli,
+        ["process", str(dataset_root), "-o", str(output_no_ext), "--view"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert view_calls == [output_corrected]
+
+


### PR DESCRIPTION
closes #265 

One consideration - currently opens even if e.g not all files were processed.
If we want to change it, should probably merge after #255 

Partial processing - Related to:
https://github.com/ida-mdc/pixel-patrol/pull/255/changes/c4bd69a0370cb654ba7bfbb2a3b854114f0591c2