### PR TITLE
fix: support bioformats2raw layout 3 OME-Zarr (closes #275)

### DIFF
--- a/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/zarr_loader.py
+++ b/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/zarr_loader.py
@@ -18,8 +18,8 @@ from pixel_patrol_loader_bio.plugins.loaders._utils import is_zarr_store
 logger = logging.getLogger(__name__)
 
 
-def _ngff_group_and_prefix(root: zarr.Group) -> Tuple[zarr.Group, str]:
-    """Return (group, component_prefix) resolving bioformats2raw layout 3 indirection."""
+def _resolve_bf2raw_group(root: zarr.Group) -> Tuple[zarr.Group, str]:
+    """Return (group, component_prefix) unwrapping the bioformats2raw layout 3 container."""
     if "bioformats2raw.layout" in dict(root.attrs) and "0" in root:
         sub = root["0"]
         if isinstance(sub, zarr.Group):
@@ -38,7 +38,7 @@ def _load_zarr_array(path: Path) -> Optional[da.Array]:
             candidates = []
 
             if isinstance(root, zarr.Group):
-                group, prefix = _ngff_group_and_prefix(root)
+                group, prefix = _resolve_bf2raw_group(root)
                 attrs = dict(group.attrs)
                 # NGFF: multiscales[0].datasets[*].path  (often "0")
                 for d in attrs.get("multiscales", [{}])[0].get("datasets", []):
@@ -89,7 +89,7 @@ def _read_zarr_root_and_primary_attrs(path: Path) -> Dict[str, Any]:
     attrs: Dict[str, Any] = {}
     try:
         root = zarr.open(str(path), mode="r")
-        group, _ = _ngff_group_and_prefix(root) if isinstance(root, zarr.Group) else (root, "")
+        group, _ = _resolve_bf2raw_group(root) if isinstance(root, zarr.Group) else (root, "")
         attrs.update(dict(getattr(group, "attrs", {}) or {}))
         try:
             if hasattr(group, "arrays"):

--- a/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/zarr_loader.py
+++ b/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/zarr_loader.py
@@ -46,14 +46,13 @@ def _load_zarr_array(path: Path) -> Optional[da.Array]:
                     if p:
                         candidates.append(prefix + p)
 
-                # Common fallbacks
-                candidates += [prefix + "0", prefix + "data", "0", "data"]
-
-                # Single-array group: use that array’s name
+                # Common fallbacks relative to the resolved group
                 if not candidates:
                     arrays = list(group.arrays())
                     if len(arrays) == 1:
                         candidates.append(prefix + arrays[0][0])
+                    else:
+                        candidates += [prefix + "0", prefix + "data"]
 
                 for comp in candidates:
                     try:

--- a/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/zarr_loader.py
+++ b/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/zarr_loader.py
@@ -18,6 +18,15 @@ from pixel_patrol_loader_bio.plugins.loaders._utils import is_zarr_store
 logger = logging.getLogger(__name__)
 
 
+def _ngff_group_and_prefix(root: zarr.Group) -> Tuple[zarr.Group, str]:
+    """Return (group, component_prefix) resolving bioformats2raw layout 3 indirection."""
+    if "bioformats2raw.layout" in dict(root.attrs) and "0" in root:
+        sub = root["0"]
+        if isinstance(sub, zarr.Group):
+            return sub, "0/"
+    return root, ""
+
+
 def _load_zarr_array(path: Path) -> Optional[da.Array]:
     try:
         # 1) Try as a direct array path
@@ -29,21 +38,22 @@ def _load_zarr_array(path: Path) -> Optional[da.Array]:
             candidates = []
 
             if isinstance(root, zarr.Group):
-                attrs = dict(root.attrs)
+                group, prefix = _ngff_group_and_prefix(root)
+                attrs = dict(group.attrs)
                 # NGFF: multiscales[0].datasets[*].path  (often "0")
                 for d in attrs.get("multiscales", [{}])[0].get("datasets", []):
                     p = d.get("path")
                     if p:
-                        candidates.append(p)
+                        candidates.append(prefix + p)
 
                 # Common fallbacks
-                candidates += ["0", "data"]
+                candidates += [prefix + "0", prefix + "data", "0", "data"]
 
                 # Single-array group: use that array’s name
                 if not candidates:
-                    arrays = list(root.arrays())
+                    arrays = list(group.arrays())
                     if len(arrays) == 1:
-                        candidates.append(arrays[0][0])
+                        candidates.append(prefix + arrays[0][0])
 
                 for comp in candidates:
                     try:
@@ -56,7 +66,7 @@ def _load_zarr_array(path: Path) -> Optional[da.Array]:
             return da.from_array(arr, chunks=arr.chunks)
         except Exception as e2:
             logger.warning(
-                f"Could not load '{path}' as a Zarr array (tried as array/group): {e1}; {e2}"
+                f"Could not load ‘{path}’ as a Zarr array (tried as array/group): {e1}; {e2}"
             )
             return None
 
@@ -73,16 +83,17 @@ def _infer_dim_order(n: int) -> str:
 
 def _read_zarr_root_and_primary_attrs(path: Path) -> Dict[str, Any]:
     """
-    Read merged attributes from the Zarr root AND the primary child array
-    (first of "0" or "data" if present). Returns a flat dict.
+    Read merged attributes from the effective NGFF group AND the primary child array.
+    Resolves bioformats2raw layout 3 indirection (root -> 0/ subgroup).
     """
     attrs: Dict[str, Any] = {}
     try:
         root = zarr.open(str(path), mode="r")
-        attrs.update(dict(getattr(root, "attrs", {}) or {}))
+        group, _ = _ngff_group_and_prefix(root) if isinstance(root, zarr.Group) else (root, "")
+        attrs.update(dict(getattr(group, "attrs", {}) or {}))
         try:
-            if hasattr(root, "arrays"):
-                for name, item in root.arrays():
+            if hasattr(group, "arrays"):
+                for name, item in group.arrays():
                     if name in ("data", "0"):
                         attrs.update(dict(getattr(item, "attrs", {}) or {}))
                         break

--- a/packages/pixel-patrol-loader-bio/tests/test_zarr_loader.py
+++ b/packages/pixel-patrol-loader-bio/tests/test_zarr_loader.py
@@ -72,3 +72,43 @@ def test_load_invalid_path_raises(tmp_path: Path, loader):
 def test_n_images_always_one(zarr_folder: Path, loader):
     info = loader.read_header(zarr_folder)
     assert info.n_images == 1
+
+
+@pytest.fixture
+def bioformats2raw_zarr(tmp_path: Path) -> Path:
+    """bioformats2raw layout 3: root has {'bioformats2raw.layout': 3}, actual OME-NGFF is under 0/."""
+    zarr_path = tmp_path / "test.ome.zarr"
+    store = LocalStore(str(zarr_path))
+    root = zarr.group(store=store)
+    root.attrs.put({"bioformats2raw.layout": 3})
+
+    sub = root.require_group("0")
+    data = np.zeros((1, 2, 8, 16, 16), dtype="uint16")
+    arr = sub.create_array("0", shape=data.shape, chunks=data.shape, dtype="uint16", overwrite=True)
+    arr[:] = data
+    sub.attrs.put({
+        "multiscales": [{
+            "version": "0.4",
+            "datasets": [{"path": "0"}],
+            "axes": [
+                {"name": "t", "type": "time"},
+                {"name": "c", "type": "channel"},
+                {"name": "z", "type": "space"},
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+        }],
+    })
+    return zarr_path
+
+
+def test_load_bioformats2raw_layout3(bioformats2raw_zarr: Path, loader):
+    rec = loader.load(bioformats2raw_zarr)
+    assert rec.dim_order == "TCZYX"
+    assert tuple(rec.data.shape) == (1, 2, 8, 16, 16)
+
+
+def test_read_header_bioformats2raw_layout3(bioformats2raw_zarr: Path, loader):
+    info = loader.read_header(bioformats2raw_zarr)
+    assert info.shape == (1, 2, 8, 16, 16)
+    assert info.dim_order == "TCZYX"


### PR DESCRIPTION
Stacked on #269.

bioformats2raw layout 3 files have `{'bioformats2raw.layout': 3}` at the zarr root with no `multiscales` there - the actual OME-NGFF metadata lives under the `0/` subgroup. The loader was finding nothing and returning `None`.

Adds `_resolve_bf2raw_group()` which detects this layout and redirects array loading and metadata extraction to `0/`.

closes #275