### PR TITLE
(typo): have image/images instead image/imagees

### DIFF
--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_table.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_table.js
@@ -205,7 +205,7 @@ function buildToolbar({ view, searchCols, searchHint, isSearching, total }, { on
   clearBtn.addEventListener('click', onClear);
 
   const countLabel = Object.assign(document.createElement('span'), {
-    textContent: `${total.toLocaleString()} ${isSearching ? 'match' : 'image'}${total !== 1 ? 'es' : ''}`,
+    textContent: `${total.toLocaleString()} ${isSearching ? 'match' : 'image'}${total !== 1 ? 's' : ''}`,
   });
   countLabel.style.cssText = 'font-size:13px;color:#6c757d';
 


### PR DESCRIPTION
Before:
<img width="582" height="215" alt="image" src="https://github.com/user-attachments/assets/4abb7072-1c63-40ad-8976-4cc76e95e106" />