### PR TITLE
fix: keep the final part when merging, instead of discarding it as stale

### DIFF
--- a/packages/pixel-patrol-aqqua/tests/test_container_partial_failure.py
+++ b/packages/pixel-patrol-aqqua/tests/test_container_partial_failure.py
@@ -1,5 +1,3 @@
-"""A sub-image that fails to load inside an otherwise-good container must be
-counted as failed, not silently dropped from every count."""
 from __future__ import annotations
 
 from pathlib import Path

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/core/processing.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/core/processing.py
@@ -1258,10 +1258,13 @@ def _coordinate_pipeline(
         "peak_worker_rss_mb":        round(peak_worker_rss_mb, 1),
         "n_memory_pressure_events":  _pause_handler.count,
         "load_cpu_s":                all_timing.get("load", 0.0),
-        "part_paths":                [str(p) for p in writer._part_paths],
         **{k: v for k, v in all_timing.items() if k.startswith("proc_")},
     }
     result_df = writer.finalize()
+    # After finalize(): it flushes the remaining buffer as one last part, so a
+    # snapshot taken before this point misses that part - and the caller, which
+    # treats anything not listed here as a stale leftover, would discard it.
+    stats["part_paths"] = [str(p) for p in writer._part_paths]
     if result_df is None:
         return None, stats  # parts on disk; caller uses save_parquet_from_parts
     return (result_df if len(result_df) > 0 else None), stats

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/core/processing.py
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/core/processing.py
@@ -1261,9 +1261,7 @@ def _coordinate_pipeline(
         **{k: v for k, v in all_timing.items() if k.startswith("proc_")},
     }
     result_df = writer.finalize()
-    # After finalize(): it flushes the remaining buffer as one last part, so a
-    # snapshot taken before this point misses that part - and the caller, which
-    # treats anything not listed here as a stale leftover, would discard it.
+    # Snapshot after finalize() so the final flushed part is included.
     stats["part_paths"] = [str(p) for p in writer._part_paths]
     if result_df is None:
         return None, stats  # parts on disk; caller uses save_parquet_from_parts

--- a/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/tifffile_loader.py
+++ b/packages/pixel-patrol-loader-bio/src/pixel_patrol_loader_bio/plugins/loaders/tifffile_loader.py
@@ -142,10 +142,7 @@ def _dask_from_series(series: tifffile.TiffPageSeries) -> da.Array:
         if isinstance(za, zarr.Group):
             # OME-TIFFs expose a multiscale group; '0' is the full-resolution array.
             za = za['0']
-        # da.from_zarr re-opens za.store via zarr.open(), which returns the Group root
-        # for multiscale stores rather than the level-0 array, causing a failure.
-        # da.from_array avoids this by using the zarr array's __getitem__ directly.
-        # "auto" regroups tiny native chunks (e.g. one row each) into ~128MB blocks.
+        # da.from_array avoids zarr.open() re-resolving the store to a Group; "auto" regroups tiny chunks.
         return da.from_array(za, chunks="auto")
     except Exception as e:
         logger.warning(

--- a/packages/pixel-patrol-loader-bio/tests/test_processing_integration.py
+++ b/packages/pixel-patrol-loader-bio/tests/test_processing_integration.py
@@ -45,6 +45,7 @@ from pixel_patrol_base.config import HISTOGRAM_BINS
 from pixel_patrol_base.core.processing import build_records_df, save_parquet_from_parts
 from pixel_patrol_base.core.processing_config import ProcessingConfig
 from pixel_patrol_base.core.project import Project
+from pixel_patrol_base.core.project_metadata import ProjectMetadata
 from pixel_patrol_base.plugins.processors.raster_processor import BasicMetricsProcessor, HistogramProcessor
 from pixel_patrol_loader_bio.plugins.loaders.tifffile_loader import TifffileLoader
 from pixel_patrol_base.plugins.processors.thumbnail_processor import ThumbnailProcessor
@@ -464,3 +465,42 @@ def test_real_parts_written_and_merged_with_correct_metadata(shared_client, tmp_
     mean_field = schema.field("mean_intensity")
     field_meta = mean_field.metadata or {}
     assert b"description" in field_meta
+
+
+def test_part_paths_lists_every_part_written(shared_client, tmp_path: Path):
+    """stats['part_paths'] must name every part on disk, including the last one.
+
+    The caller discards any part not listed here as a stale leftover, so a
+    missing entry silently drops that part's rows - with no failure reported.
+    The final part is the one at risk: it is flushed by finalize(), after the
+    rest of the stats have been gathered.
+    """
+    images = tmp_path / "images"
+    images.mkdir()
+    rng = np.random.default_rng(0)
+    # Plain 2D frames so each image contributes exactly one row, which makes the
+    # flush arithmetic below exact.
+    n_images = 6
+    for i in range(n_images):
+        tifffile.imwrite(images / f"img_{i}.tif",
+                         rng.integers(0, 255, size=(32, 32), dtype=np.uint8),
+                         photometric="minisblack")
+
+    parts_dir = tmp_path / "parts"
+    # 6 rows at 4 per part: one part spills mid-run and 2 rows are left in the
+    # buffer, so finalize() has a final part to flush. Without that remainder the
+    # bug cannot appear, because there is no last part to omit.
+    config = ProcessingConfig(rows_per_part=4)
+    df, stats = _build([images], config, images, parts_dir=parts_dir)
+
+    assert df is None, "expected the run to spill to parts, not stay in memory"
+    on_disk = set(parts_dir.glob("part_*.parquet"))
+    assert len(on_disk) > 1, "test needs a final part flushed by finalize()"
+    listed = {Path(p) for p in stats["part_paths"]}
+    assert listed == on_disk, f"parts on disk not listed in stats: {sorted(on_disk - listed)}"
+
+    # And the merged output keeps every row those parts hold.
+    out = tmp_path / "out.parquet"
+    written = save_parquet_from_parts(sorted(on_disk), out, ProjectMetadata(project_name="t"))
+    expected = sum(pl.read_parquet(p).height for p in sorted(on_disk))
+    assert written == expected == pl.read_parquet(out).height

--- a/packages/pixel-patrol-loader-bio/tests/test_tifffile_loader.py
+++ b/packages/pixel-patrol-loader-bio/tests/test_tifffile_loader.py
@@ -154,21 +154,14 @@ def test_load_pyramidal_ome_tiff_is_lazy_and_chunked(tmp_path: Path, loader, cap
         tif.write(im, subifds=1, tile=(tile, tile), **opts)
         tif.write(im[:, ::2, ::2], subfiletype=1, tile=(tile, tile), **opts)
 
-    # Confirm the TIFF has multiple resolution levels (triggers the multiscale
-    # zarr store, which is the path that previously caused the failure).
     with tifffile.TiffFile(path) as tf:
         assert len(tf.series[0].levels) > 1, "fixture must produce a multiscale series"
 
     with caplog.at_level(logging.WARNING):
         rec = loader.load(path)
 
-    # The zarr/aszarr path must have succeeded directly; the exception fallback
-    # (series.asarray() + da.from_array) logs this warning when it fires.
     assert "aszarr/Zarr failed" not in caplog.text, "must not silently fall back to eager load"
 
-    # Result must be a lazy dask array, not an in-memory numpy array.
     import dask.array as da
     assert isinstance(rec.data, da.Array), "load() must return a lazy dask array"
-
-    # Data must round-trip correctly.
     np.testing.assert_array_equal(rec.data.compute(), im)


### PR DESCRIPTION
A run that spills to parts silently lost the last part's rows, reporting n_images_failed: 0 while doing so. On the EuroSAT example dataset that meant 26,455 of 27,000 files reaching the report, with only

    Project Core: ignoring 1 unexpected leftover part file(s)

to show for it.

The caller treats any part not named in stats["part_paths"] as a leftover from an earlier run and skips it, which is right. The problem is upstream: the stats dict is built - copying writer._part_paths - and only then is finalize() called, which flushes whatever is left in the buffer as one final part. That part is therefore never in the list, and is dropped.

The rows at risk are exactly the remainder that did not fill a part, so the loss is largest for the datasets least likely to be checked by hand: any run big enough to spill, ending on a partial part.

Snapshot part_paths after finalize() instead.

The existing tests covered only the consuming side, asserting that a part absent from part_paths is ignored - true, and precisely why this went unnoticed. Nothing checked that the producer lists every part it wrote. The added integration test does, driving the real pipeline with a row budget chosen so one part spills mid-run and a remainder is left for finalize() to flush. It fails without this change, naming the dropped part.