### PR TITLE
fix mixed-group container files in summary, sunburst, file metadata

### DIFF
--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_file_stats.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_file_stats.js
@@ -1,3 +1,5 @@
+export const MIXED_GROUP_WARNING = 'Some files contain images from multiple groups - file count and size cannot be attributed to a single group.';
+
 const SIZE_NUM_BINS      = 20;
 const SIZE_LOG_THRESHOLD = 30;
 const MAX_DAYS           = 20;
@@ -30,6 +32,9 @@ export default {
 
   async overviewMessage(ctx) {
     try {
+      if (ctx.withinFileGroupVariation) {
+        return { text: MIXED_GROUP_WARNING, warning: true };
+      }
       const { andWhere, groupCol: gcFn, fileCount } = ctx.sql;
       const { escapeHtml } = ctx.plot;
       const [extRows, groupRows] = await Promise.all([
@@ -50,8 +55,25 @@ export default {
 
   async overviewPlot(container, ctx) {
     const { andWhere, groupCol: gcFn, fileCount } = ctx.sql;
-    const gcExpr = gcFn();
 
+    if (ctx.withinFileGroupVariation) {
+      const groupRows = await ctx.queryRows(`
+        SELECT ${gcFn()} AS g, COUNT(*) AS c
+        FROM pp_data ${ctx.where} GROUP BY 1 ORDER BY 1
+      `);
+      if (!groupRows.length) return false;
+      const groups = groupRows.map(r => String(r.g));
+      ctx.plot.appendMini(container, [{
+        type: 'bar',
+        x: groups.map(g => ctx.groupLabel(g)),
+        y: groupRows.map(r => Number(r.c)),
+        marker: { color: groups.map(g => ctx.colorMap[g] ?? '#6c757d') },
+        hoverinfo: 'skip',
+      }], { xaxis: { type: 'category' }, bargap: 0.3 });
+      return true;
+    }
+
+    const gcExpr = gcFn();
     const [extRows, groupRows] = await Promise.all([
       ctx.queryRows(`
         SELECT "file_extension" AS ext, ${gcExpr} AS __group__, ${fileCount()} AS c
@@ -142,13 +164,12 @@ export default {
   async render(container, ctx) {
     try {
       const invariants = [];
-      const [extRows, sizeRange, dateRange] = await fetchFileStats(ctx);
-
-      // Each section draws a chart when the property varies, or adds an
-      // invariant row when it's shared by every file.
-      renderExtensions(container, ctx, extRows, invariants);
-      await renderSizeBins(container, ctx, sizeRange, invariants);
-      await renderModificationDates(container, ctx, dateRange, invariants);
+      const ungrouped = ctx.withinFileGroupVariation;
+      if (ungrouped) ctx.plot.prependWarning(container, { level: 'yellow', html: MIXED_GROUP_WARNING });
+      const [extRows, sizeRange, dateRange] = await fetchFileStats(ctx, { ungrouped });
+      renderExtensions(container, ctx, extRows, invariants, { ungrouped });
+      await renderSizeBins(container, ctx, sizeRange, invariants, { ungrouped });
+      await renderModificationDates(container, ctx, dateRange, invariants, { ungrouped });
 
       if (invariants.length) ctx.plot.invariantTable(container, {
         title: 'Properties shared by all files that report it',
@@ -166,9 +187,9 @@ export default {
 };
 
 // The three datasets the full view needs, fetched in parallel.
-function fetchFileStats(ctx) {
-  const { perFile, andWhere, groupCol: gcFn } = ctx.sql;
-  const gcExpr  = gcFn();
+function fetchFileStats(ctx, { ungrouped = false } = {}) {
+  const { perFile, andWhere } = ctx.sql;
+  const gcExpr  = gcExprFor(ctx, ungrouped);
   const hasDate = ctx.schema.allCols.includes('modification_date');
   return Promise.all([
     ctx.queryRows(`
@@ -196,27 +217,29 @@ function fetchFileStats(ctx) {
 }
 
 // One shared extension → invariant row; several → red warning + count/size bars.
-function renderExtensions(container, ctx, extRows, invariants) {
+function renderExtensions(container, ctx, extRows, invariants, { ungrouped = false } = {}) {
   const exts = [...new Set(extRows.map(r => String(r.ext)))].sort();
   if (!exts.length) return;
   if (exts.length === 1) {
     invariants.push(['File Extension', exts[0]]);
     return;
   }
-  ctx.plot.prependWarning(container, {
-    level: 'red',
-    html: `This dataset contains files with more than one extension: ` +
-      `${exts.map(e => ctx.plot.escapeHtml(e)).join(', ')}. ` +
-      `Mixed file formats can mean a mixed dataset or even images that were saved twice - worth looking into.`,
-  });
+  if (!ungrouped) {
+    ctx.plot.prependWarning(container, {
+      level: 'red',
+      html: `This dataset contains files with more than one extension: ` +
+        `${exts.map(e => ctx.plot.escapeHtml(e)).join(', ')}. ` +
+        `Mixed file formats can mean a mixed dataset or even images that were saved twice - worth looking into.`,
+    });
+  }
   renderGroupedBars(container, { categories: exts, getValue: pick(extRows, r => r.ext, 'count'),
-    title: 'File Count by Extension', xLabel: 'Extension', yLabel: 'File count' }, ctx);
+    title: 'File Count by Extension', xLabel: 'Extension', yLabel: 'File count' }, ctx, { ungrouped });
   renderGroupedBars(container, { categories: exts, getValue: pick(extRows, r => r.ext, 'total_bytes'),
-    title: 'Total Size by Extension', xLabel: 'Extension', yLabel: 'Total size (bytes)' }, ctx);
+    title: 'Total Size by Extension', xLabel: 'Extension', yLabel: 'Total size (bytes)' }, ctx, { ungrouped });
 }
 
 // One distinct size → invariant row; otherwise a count-per-size-bin chart.
-async function renderSizeBins(container, ctx, sizeRange, invariants) {
+async function renderSizeBins(container, ctx, sizeRange, invariants, { ungrouped = false } = {}) {
   const minS  = Number(sizeRange[0]?.min_s ?? 0);
   const maxS  = Number(sizeRange[0]?.max_s ?? 0);
   const nUniq = Number(sizeRange[0]?.n_unique ?? 0);
@@ -226,8 +249,9 @@ async function renderSizeBins(container, ctx, sizeRange, invariants) {
   }
   const { breaks, labels, useLog } = computeSizeBins(minS, maxS, nUniq, ctx.plot.formatBytes);
   if (!breaks.length) return;
+  const gcExpr = gcExprFor(ctx, ungrouped);
   const rows = await ctx.queryRows(`
-    SELECT ${buildSizeCaseSQL(breaks, labels)} AS bin, ${ctx.sql.groupCol()} AS __group__, ${ctx.sql.fileCount()} AS count
+    SELECT ${buildSizeCaseSQL(breaks, labels)} AS bin, ${gcExpr} AS __group__, ${ctx.sql.fileCount()} AS count
     FROM pp_data ${ctx.sql.andWhere(ctx.where, '"size_bytes" IS NOT NULL')}
     GROUP BY 1, 2
   `);
@@ -235,14 +259,14 @@ async function renderSizeBins(container, ctx, sizeRange, invariants) {
     categories: labels, getValue: pick(rows, r => r.bin, 'count'),
     title: 'File Count by Size Bin',
     xLabel: useLog ? 'File size (log-spaced bins)' : 'File size bin', yLabel: 'File count', showLegend: true,
-  }, ctx);
+  }, ctx, { ungrouped });
 }
 
 // One exact timestamp shared by every file → invariant row with full precision.
 // Otherwise a timeline, bucketed at whatever granularity (day/hour/minute/second)
 // actually shows spread - rolled up to months if there are too many distinct days,
 // or collapsed to a compact range if the spread is sub-second and no bucket would help.
-export async function renderModificationDates(container, ctx, dateRange, invariants) {
+export async function renderModificationDates(container, ctx, dateRange, invariants, { ungrouped = false } = {}) {
   const { min_fmt: minFmt, max_fmt: maxFmt, span_ms: spanMsRaw, n_unique: nUniqueRaw } = dateRange[0] ?? {};
   if (minFmt == null) return;
 
@@ -265,24 +289,30 @@ export async function renderModificationDates(container, ctx, dateRange, invaria
                          : spanMs >= MS_MINUTE ? ['%Y-%m-%d %H:%M', 'Minute']
                          :                       ['%Y-%m-%d %H:%M:%S', 'Second'];
 
-  let { rows, cats } = await bucketByDateFmt(ctx, fmt);
+  let { rows, cats } = await bucketByDateFmt(ctx, fmt, { ungrouped });
   let finalLabel = dateLabel;
   if (fmt === '%Y-%m-%d' && cats.length > MAX_DAYS) {
-    ({ rows, cats } = await bucketByDateFmt(ctx, '%Y-%m'));
+    ({ rows, cats } = await bucketByDateFmt(ctx, '%Y-%m', { ungrouped }));
     finalLabel = 'Month';
   }
 
   renderGroupedBars(container, {
     categories: cats, getValue: pick(rows, r => r.bucket, 'count'),
     title: 'File Count by Modification Date', xLabel: finalLabel, yLabel: 'File count', showLegend: true,
-  }, ctx);
+  }, ctx, { ungrouped });
+}
+
+// Returns the group column SQL expression, or a constant when grouping is suppressed.
+function gcExprFor(ctx, ungrouped) {
+  return ungrouped ? "'_all_'" : ctx.sql.groupCol();
 }
 
 // Group modification_date into buckets of the given STRFTIME format.
-async function bucketByDateFmt(ctx, fmt) {
+async function bucketByDateFmt(ctx, fmt, { ungrouped = false } = {}) {
+  const gcExpr = gcExprFor(ctx, ungrouped);
   const rows = await ctx.queryRows(`
     SELECT STRFTIME(TRY_CAST("modification_date" AS TIMESTAMP), '${fmt}') AS bucket,
-           ${ctx.sql.groupCol()} AS __group__, ${ctx.sql.fileCount()} AS count
+           ${gcExpr} AS __group__, ${ctx.sql.fileCount()} AS count
     FROM pp_data ${ctx.sql.andWhere(ctx.where, '"modification_date" IS NOT NULL')}
     GROUP BY 1, 2 ORDER BY 1, 2
   `);
@@ -295,9 +325,12 @@ function pick(rows, catOf, valueKey) {
   return (cat, g) => m.get(`${cat}\x00${g}`) ?? 0;
 }
 
-function renderGroupedBars(container, { categories, getValue, title, xLabel, yLabel, showLegend = true }, ctx) {
-  const legend = showLegend && ctx.groups.length > 1;
-  ctx.plot.append(container, ctx.plot.groupedBarTraces(categories, getValue), {
+function renderGroupedBars(container, { categories, getValue, title, xLabel, yLabel, showLegend = true }, ctx, { ungrouped = false } = {}) {
+  const traces = ungrouped
+    ? [{ type: 'bar', x: categories, y: categories.map(c => getValue(c, '_all_')), marker: { color: '#6c757d' } }]
+    : ctx.plot.groupedBarTraces(categories, getValue);
+  const legend = !ungrouped && showLegend && ctx.groups.length > 1;
+  ctx.plot.append(container, traces, {
     margin:     FILE_STATS_MARGIN,
     title:      { text: title },
     barmode:    'stack',

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_summary.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_summary.js
@@ -1,3 +1,5 @@
+import { MIXED_GROUP_WARNING } from './plugin_file_stats.js';
+
 export default {
   id: 'summary',
   required_inputs: ['size_bytes', 'file_extension'],
@@ -41,10 +43,20 @@ export default {
 
       // In overview mode the summary is a bare header; the uneven-group warning
       // is surfaced in the File Metadata tile instead.
-      if (summary.nGroups > 1 && !ctx.state.overviewMode) prependUnevenGroupWarning(container, ctx, rows);
+      if (summary.nGroups > 1 && !ctx.state.overviewMode && !ctx.withinFileGroupVariation) prependUnevenGroupWarning(container, ctx, rows);
       renderKpis(container, ctx, summary);
       renderMetaLines(container, ctx, summary);
-      if (summary.nGroups > 1) renderGroupTable(container, ctx, rows, summary);
+      if (ctx.withinFileGroupVariation && summary.nGroups > 1) {
+        ctx.plot.prependWarning(container, { level: 'yellow', html: MIXED_GROUP_WARNING });
+        container.appendChild(container.firstChild); // move from top to after KPI/meta lines
+      }
+      if (summary.nGroups > 1) {
+        const mixed = ctx.withinFileGroupVariation;
+        const imageCounts = (mixed && summary.hasContainerFiles)
+          ? await fetchImageCountsPerGroup(ctx)
+          : null;
+        renderGroupTable(container, ctx, rows, summary, { mixed, imageCounts });
+      }
     } catch {
       container.innerHTML = '<div class="no-data">Failed to load data.</div>';
     }
@@ -67,6 +79,14 @@ function fetchSummary(ctx) {
   ]);
 }
 
+// Image count per group queried directly from pp_data (accurate even for mixed-group files).
+async function fetchImageCountsPerGroup(ctx) {
+  const rows = await ctx.queryRows(
+    `SELECT ${ctx.sql.groupCol()} AS g, COUNT(*) AS n FROM pp_data ${ctx.where} GROUP BY 1`
+  );
+  return Object.fromEntries(rows.map(r => [String(r.g), Number(r.n)]));
+}
+
 // Derive the headline numbers and labels the view needs.
 function summarize(ctx, rows, [totals = {}]) {
   const extensions = new Set();
@@ -74,13 +94,16 @@ function summarize(ctx, rows, [totals = {}]) {
 
   const groupCol            = ctx.state.groupCol ?? 'group';
   const isImportedPathShort = groupCol === 'imported_path_short';
+  const totalFiles          = Number(totals.file_count ?? 0);
+  const totalImages         = Number(totals.image_count ?? 0);
 
   return {
     nGroups:       rows.length,
     extensions,
-    totalFiles:    Number(totals.file_count ?? 0),
-    totalImages:   Number(totals.image_count ?? 0),
+    totalFiles,
+    totalImages,
     totalBytes:    Number(totals.total_bytes ?? 0),
+    hasContainerFiles: totalImages > totalFiles,
     isImportedPathShort,
     groupColLabel: isImportedPathShort ? groupCol : ctx.plot.niceName(groupCol),
   };
@@ -140,34 +163,45 @@ function renderMetaLines(container, ctx, s) {
   }
 }
 
-// Per-group breakdown table with inline bar cells for file count and size.
-function renderGroupTable(container, ctx, rows, s) {
+// Per-group breakdown table with inline bar cells for file count, images, and size.
+// When mixed=true (files span multiple groups), Files and Size columns are hidden.
+// imageCounts, if provided, overrides the per-row image_count with accurate pp_data counts.
+function renderGroupTable(container, ctx, rows, s, { mixed = false, imageCounts = null } = {}) {
   const { escapeHtml, formatBytes } = ctx.plot;
-  const showExtCol   = s.extensions.size > 1;
-  const maxFileCount = Math.max(...rows.map(r => Number(r.file_count)));
-  const maxBytes     = Math.max(...rows.map(r => Number(r.total_bytes ?? 0)));
+  const showExtCol    = s.extensions.size > 1;
+  const showImages    = s.hasContainerFiles;
+  const showFilesSize = !mixed;
+  const getImageCount = r => imageCounts ? (imageCounts[String(r.__group__)] ?? 0) : Number(r.image_count ?? 0);
+
+  const maxFileCount  = showFilesSize ? Math.max(...rows.map(r => Number(r.file_count))) : 0;
+  const maxBytes      = showFilesSize ? Math.max(...rows.map(r => Number(r.total_bytes ?? 0))) : 0;
+  const maxImageCount = showImages    ? Math.max(...rows.map(getImageCount)) : 0;
+
   const table = document.createElement('table');
   table.className = 'stat-table';
   table.innerHTML = `
     <thead>
       <tr>
         <th>${escapeHtml(s.groupColLabel)}</th>
-        <th>Files</th>
-        <th>Size</th>
-        ${showExtCol ? '<th>File Extension</th>' : ''}
+        ${showFilesSize ? '<th>Files</th>' : ''}
+        ${showImages    ? '<th>Images</th>' : ''}
+        ${showFilesSize ? '<th>Size</th>' : ''}
+        ${showExtCol    ? '<th>File Extension</th>' : ''}
       </tr>
     </thead>
     <tbody>
       ${rows.map(r => {
-        const color     = ctx.color.group(String(r.__group__));
-        const fileCount = Number(r.file_count);
-        const bytes     = Number(r.total_bytes ?? 0);
+        const color      = ctx.color.group(String(r.__group__));
+        const fileCount  = Number(r.file_count);
+        const imageCount = getImageCount(r);
+        const bytes      = Number(r.total_bytes ?? 0);
         return `
         <tr>
           <td><span class="group-color-dot" style="background:${color}"></span>${escapeHtml(ctx.groupLabel(String(r.__group__)))}</td>
-          <td>${barCell(fileCount, maxFileCount, color, fileCount.toLocaleString())}</td>
-          <td>${barCell(bytes, maxBytes, color, formatBytes(bytes))}</td>
-          ${showExtCol ? `<td>${escapeHtml(formatFileTypes(r.file_types))}</td>` : ''}
+          ${showFilesSize ? `<td>${barCell(fileCount, maxFileCount, color, fileCount.toLocaleString())}</td>` : ''}
+          ${showImages    ? `<td>${barCell(imageCount, maxImageCount, color, imageCount.toLocaleString())}</td>` : ''}
+          ${showFilesSize ? `<td>${barCell(bytes, maxBytes, color, formatBytes(bytes))}</td>` : ''}
+          ${showExtCol    ? `<td>${escapeHtml(formatFileTypes(r.file_types))}</td>` : ''}
         </tr>
       `;
       }).join('')}

--- a/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_sunburst.js
+++ b/packages/pixel-patrol-base/src/pixel_patrol_base/viewer/plugin_sunburst.js
@@ -132,6 +132,7 @@ async function countFiles(ctx) {
 }
 
 // One row per folder (with file count + size) when rolled up, else one per file.
+// For the file-level case, is_mixed flags files whose images span multiple groups.
 function fetchSunburstRows(ctx, { foldersOnly, pathWhere }) {
   const gcExpr = ctx.sql.groupCol();
   const src    = ctx.sql.perFile(pathWhere);
@@ -146,9 +147,17 @@ function fetchSunburstRows(ctx, { foldersOnly, pathWhere }) {
         GROUP BY 1, 2
       `)
     : ctx.queryRows(`
-        SELECT "path", ${gcExpr} AS __group__,
-               __n_images__::INTEGER AS __images__, "size_bytes"::BIGINT AS __size__
+        WITH mixed AS (
+          SELECT "path", COUNT(DISTINCT ${gcExpr}) > 1 AS is_mixed
+          FROM pp_data ${pathWhere}
+          GROUP BY "path"
+        )
+        SELECT pp_file."path", ${gcExpr} AS __group__,
+               pp_file.__n_images__::INTEGER AS __images__,
+               pp_file."size_bytes"::BIGINT AS __size__,
+               COALESCE(m.is_mixed, false) AS is_mixed
         FROM ${src}
+        LEFT JOIN mixed m ON pp_file."path" = m."path"
       `);
 }
 
@@ -163,11 +172,12 @@ function buildHierarchy(rows, colorMap, { foldersOnly, mode }) {
     if (commonRoot && rel.startsWith(commonRoot)) rel = rel.slice(commonRoot.length);
     rel = rel.replace(/^[/\\]+/, '');
     return {
-      path:   rel,
-      group:  String(r.__group__),
-      files:  foldersOnly ? num(r.__n__) : 1,
-      images: num(r.__images__),
-      bytes:  num(r.__size__),
+      path:    rel,
+      group:   String(r.__group__),
+      files:   foldersOnly ? num(r.__n__) : 1,
+      images:  num(r.__images__),
+      bytes:   num(r.__size__),
+      isMixed: !foldersOnly && Boolean(r.is_mixed),
     };
   });
 
@@ -192,7 +202,7 @@ function buildHierarchy(rows, colorMap, { foldersOnly, mode }) {
       fileId = rootName ? `${rootName}${sep}${path}` : path;
       const parentId = getParentId(fileId, sep, rootName);
       nodeStats[fileId]  = { files: rec.files, images: rec.images, bytes: rec.bytes };
-      nodeGroups[fileId] = new Set([group]);
+      nodeGroups[fileId] = rec.isMixed ? new Set([group, '__mixed__']) : new Set([group]);
       nodeParent[fileId] = parentId;
       nodeLabel[fileId]  = parts[parts.length - 1] || fileId;
     }

--- a/viewer/src/renderer.js
+++ b/viewer/src/renderer.js
@@ -42,7 +42,7 @@ import { scopeBadgeHtml, setScopeBadge } from './scopes.js';
  * @property {() => string[]} color.getPaletteNames  lists the available
  *   palette names accepted by color.getColors.
  */
-function buildCtx(conn, schema, state, colorMap, where, userWhere, groups, filteredCount, totalRows) {
+function buildCtx(conn, schema, state, colorMap, where, userWhere, groups, filteredCount, totalRows, { withinFileGroupVariation = false } = {}) {
   const legend = legendWithGrouping(LEGEND, state, '');
   const groupLabels = buildGroupLabels(groups);
   plotEngine.setDateCols(schema.dateCols ?? []);
@@ -55,6 +55,7 @@ function buildCtx(conn, schema, state, colorMap, where, userWhere, groups, filte
     userWhere,
     groups,
     groupLabels,
+    withinFileGroupVariation,
     groupLabel: (g) => groupLabels[g] ?? String(g),
     filteredCount,
     totalRows,
@@ -255,23 +256,31 @@ export async function renderAll(plugins, conn, schema, state, totalRows) {
   const userWhere = buildWhere(state.filter);
   const where = buildScopedWhere(schema, state);
 
-  // Fetch distinct groups and filtered count in parallel.
+  // Fetch distinct groups, filtered count, and within-file group variation in parallel.
   const gcExpr = state.groupCol ? _q(state.groupCol) : `'${GROUP_ALL}'`;
-  const [groupResult, countResult] = await Promise.all([
+  const hasPaths = schema.allCols.includes('path');
+  const [groupResult, countResult, mixedResult] = await Promise.all([
     conn.query(
       `SELECT DISTINCT ${gcExpr} AS g FROM pp_data ${where} ORDER BY 1 LIMIT 50`,
     ),
     conn.query(`SELECT COUNT(*) AS n FROM pp_data ${where}`),
+    hasPaths && state.groupCol
+      ? conn.query(`SELECT COUNT(*) AS n FROM (SELECT "path" FROM pp_data ${where} GROUP BY "path" HAVING COUNT(DISTINCT ${_q(state.groupCol)}) > 1)`)
+      : Promise.resolve(null),
   ]);
 
   const groups = sortGroups(groupResult.toArray().map(r => String(r.g)));
   const filteredCount = Number(countResult.toArray()[0].n);
   const colorMap     = buildColorMap(groups, state.palette);
+  const withinFileGroupVariation = mixedResult
+    ? Number(mixedResult.toArray()[0]?.n ?? 0) > 0
+    : false;
 
   updateFilteredInfo(filteredCount, totalRows);
 
   const ctx = buildCtx(
     conn, schema, state, colorMap, where, userWhere, groups, filteredCount, totalRows,
+    { withinFileGroupVariation },
   );
 
   const container = document.getElementById(WIDGET_CONTAINER_ID);


### PR DESCRIPTION
I saw a small plotly bug when sometimes sunburst root is  colored only on first open. Not sure it's worth fixing. Possibly plotly and not our bug.

Closes #291 